### PR TITLE
Refresh the dolrecomp copy when the recompiler changes, not when the port relinks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,10 +599,21 @@ if(MODERNGEKKO_ENABLE_DOLPHIN_RUNTIME)
             MODERNGEKKO_DOLRECOMP_LLVM=1)
     endif()
     add_dependencies(moderngekko-port dolrecomp moderngekko-run)
-    add_custom_command(TARGET moderngekko-port POST_BUILD
+    # A custom target rather than POST_BUILD on moderngekko-port. POST_BUILD only
+    # fires when its own target relinks, so bumping DolRecomp rebuilt the
+    # recompiler while leaving the stale copy in place -- and moderngekko-port
+    # runs the copy beside itself, so it silently kept recompiling with the old
+    # binary and reported success. It cannot hang off dolrecomp either:
+    # add_custom_command(TARGET) requires the target be defined in the same
+    # directory, and dolrecomp comes from add_subdirectory. A custom target is
+    # always considered out of date, and copy_if_different makes that cheap.
+    add_custom_target(moderngekko-port-recompiler ALL
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 "$<TARGET_FILE:dolrecomp>"
-                "$<TARGET_FILE_DIR:moderngekko-port>")
+                "$<TARGET_FILE_DIR:moderngekko-port>"
+        DEPENDS dolrecomp
+        COMMENT "Refreshing dolrecomp beside moderngekko-port")
+    add_dependencies(moderngekko-port moderngekko-port-recompiler)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
`moderngekko-port` runs `dolrecomp.exe` from its own directory, and that file is a copy produced by a `POST_BUILD` command attached to `moderngekko-port`:

```cmake
add_custom_command(TARGET moderngekko-port POST_BUILD
    COMMAND ${CMAKE_COMMAND} -E copy_if_different
            "$<TARGET_FILE:dolrecomp>" "$<TARGET_FILE_DIR:moderngekko-port>")
```

`POST_BUILD` only fires when its own target relinks. Bump DolRecomp and rebuild, and the recompiler is rebuilt while `moderngekko-port` — whose sources have not changed — is not, so the copy is left alone. Every module generated after that uses the **old** recompiler, and the build reports success.

### How it turned up

Bumping a vendored DolRecomp to a newer revision and rebuilding. The generated code kept coming out without a fix that was demonstrably present in the new recompiler. Three `dolrecomp.exe` on disk disagreed:

| Path | Carried the new emitter change |
|---|---|
| `build/dolrecomp.exe` — the copy actually invoked | no |
| `build/vendor/dolphin/DolRecomp/dolrecomp.exe` | yes |
| the separately built `lib/DolRecomp/build/dolrecomp.exe` | yes |

Nothing in the output suggested a stale binary; it looked like the recompiler change simply had not taken effect.

The module cache compounds it. With the stale copy in place the cache key does not change either, so a rebuild reports `cache hit` and reuses the previous module — the old recompiler twice over.

### The fix

Moving it to `dolrecomp`'s own `POST_BUILD` does not work: `add_custom_command(TARGET ...)` requires the target be defined in the same directory, and `dolrecomp` arrives via `add_subdirectory`. That is presumably why it was attached to `moderngekko-port` in the first place.

A custom target has no such restriction, is always considered out of date, and `copy_if_different` keeps that cheap:

```cmake
add_custom_target(moderngekko-port-recompiler ALL
    COMMAND ${CMAKE_COMMAND} -E copy_if_different
            "$<TARGET_FILE:dolrecomp>" "$<TARGET_FILE_DIR:moderngekko-port>"
    DEPENDS dolrecomp
    COMMENT "Refreshing dolrecomp beside moderngekko-port")
add_dependencies(moderngekko-port moderngekko-port-recompiler)
```

### Verified

Touched a DolRecomp source and rebuilt only `moderngekko-port`:

```
[2/11] Linking C executable vendor\dolphin\DolRecomp\dolrecomp.exe
[3/11] Refreshing dolrecomp beside moderngekko-port
[5/8]  Linking CXX executable moderngekko-port.exe
```

and the copy is byte-identical to the freshly built recompiler. Before the change the same sequence left the copy untouched.

I did try attaching it to `dolrecomp` first — worth mentioning only because it does not configure at all, so if that shape looks tidier, it is not available here.
