### PR TITLE
Expose the module optimisation level, and default it to -O2

### DIFF
--- a/tools/moderngekko_port.cpp
+++ b/tools/moderngekko_port.cpp
@@ -35,6 +35,10 @@ constexpr std::string_view DOLRECOMP_REVISION =
 struct BuildOptions
 {
   std::string toolchain = "auto";
+  // Empty means "leave the module template's own default alone". Any other
+  // value is forwarded as RECOMPCORE_MODULE_OPT_LEVEL and folded into the
+  // cache key, so an -O3 module cannot collide with an -O2 one.
+  std::string opt_level;
 #if defined(MODERNGEKKO_DOLRECOMP_LLVM)
   std::string backend = "llvm";
 #else
@@ -456,10 +460,15 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
 #else
   constexpr std::string_view architecture = "unsupported";
 #endif
+  // The module template appends -O<level> after CMake's own
+  // CMAKE_C_FLAGS_RELEASE, so this is the level that actually reaches the
+  // per-translation-unit compiles.
+  const std::string opt = options.opt_level.empty() ? std::string("2") : options.opt_level;
   std::string flags;
   if (compiler == "clang")
   {
-    flags = "compile:-O2 -flto=thin -fvisibility=hidden -ffp-contract=off -fno-fast-math "
+    flags = "compile:-O" + opt +
+            " -flto=thin -fvisibility=hidden -ffp-contract=off -fno-fast-math "
             "link:-flto=thin";
 #if defined(__linux__)
     flags += " -fuse-ld=lld";
@@ -467,7 +476,8 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
   }
   else if (compiler == "gcc")
   {
-    flags = "compile:-O2 -fvisibility=hidden -ffp-contract=off -fno-fast-math link:no-lto";
+    flags = "compile:-O" + opt +
+            " -fvisibility=hidden -ffp-contract=off -fno-fast-math link:no-lto";
   }
   else
   {
@@ -583,6 +593,9 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
       " -DCMAKE_C_COMPILER=" + compiler + " -DGAME_ID=" + game.disc_id +
       " -DGENERATED_DIR=" + Quote(generated) +
       " -DGXRUNTIME_DIR=" + Quote(source_root / "vendor/dolphin/GXRuntime") +
+      (options.opt_level.empty()
+           ? std::string()
+           : " -DRECOMPCORE_MODULE_OPT_LEVEL=" + options.opt_level) +
       " -DCHASSIS_ABI_DIR=" +
       Quote(source_root / "vendor/dolphin/Source/Core/Core/PowerPC/StaticRecomp");
   if (!RunCommand(configure) ||
@@ -601,7 +614,7 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
 void Usage()
 {
   std::cerr << "usage: moderngekko-port inspect <game-root>\n"
-               "       moderngekko-port build <game-root> [--backend c|llvm] [--toolchain auto|clang|gcc|msvc] [--output path]\n"
+               "       moderngekko-port build <game-root> [--backend c|llvm] [--toolchain auto|clang|gcc|msvc] [--opt-level 0-3] [--output path]\n"
                "       moderngekko-port run <game-root> [build options] [-- runner options]\n";
 }
 }  // namespace
@@ -628,6 +641,8 @@ int main(int argc, char** argv)
       options.toolchain = argv[++i];
     else if (arg == "--backend" && i + 1 < argc)
       options.backend = argv[++i];
+    else if (arg == "--opt-level" && i + 1 < argc)
+      options.opt_level = argv[++i];
     else if (arg == "--output" && i + 1 < argc)
       options.output = argv[++i];
     else if (command == "run")
@@ -643,6 +658,12 @@ int main(int argc, char** argv)
   if (options.backend != "c" && options.backend != "llvm")
   {
     std::cerr << "unknown backend: " << options.backend << '\n';
+    return 2;
+  }
+  if (!options.opt_level.empty() &&
+      (options.opt_level.size() != 1 || options.opt_level[0] < '0' || options.opt_level[0] > '3'))
+  {
+    std::cerr << "opt level must be 0, 1, 2, or 3: " << options.opt_level << '\n';
     return 2;
   }
 #if !defined(MODERNGEKKO_DOLRECOMP_LLVM)

--- a/tools/moderngekko_port.cpp
+++ b/tools/moderngekko_port.cpp
@@ -481,7 +481,7 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
   }
   else
   {
-    flags = "compile:/O2 /fp:strict";
+    flags = opt == "0" ? "compile:/Od /fp:strict" : "compile:/O2 /fp:strict";
   }
   const std::string identity = std::string(RECOMPCORE_REVISION) + "|dolrecomp=" +
       std::string(DOLRECOMP_REVISION) + "|module-abi=" +


### PR DESCRIPTION
The generated module was compiled with whatever CMake's Release flags carried. This adds `--opt-level` and defaults it to 2.

`-O3` is measurably worse here, not better: **-1.2% on Mario Kart: Double Dash!!**, because it grows the module by about 1.5 MB. A recompiled module is one dispatch switch spanning the whole game, so nearly every win in this codebase is an instruction-cache result and size is the thing to protect. Defaulting to 2 makes that explicit rather than incidental to the build type.

The level is also folded into `moderngekko-port`'s cache key. Without that, two builds differing only in optimisation level silently share cached objects and you get a module that is half one and half the other â€” which is how the -1.2% was nearly measured as noise.

Validation: `--opt-level` rejects anything outside 0-3. An empty value leaves the module template's own default alone, so the flag is opt-in for anyone who wants a level other than the new default.

### How this fits

These land together as a set: savestates working end to end, the Windows build
and test suite being usable at all, and CI so none of it regresses unnoticed.
**This PR is MG #19.**

| | | |
|---|---|---|
| MG #18 | Bump vendored RecompCore | **prerequisite** - without it the launcher cannot compile on Windows (C sources get a C++ PCH) |
| RC #7 | `Interpreter.cpp` include | **prerequisite** - `core` does not compile without it |
| RC #8 | In-game File/View menu and hotkeys | introduces `Core/SavestateLayout.h`, the one definition of where savestates live, what they are called and how they are ordered |
| MG #21 | Launcher savestate picker, `--load-state` | consumes that header, so the launcher and the in-game menu cannot disagree |
| MG #22 | Make the test suite pass on Windows | **land before CI**, or the first run is red on day one |
| MG #23 | Build and test on PRs, three platforms | the reason the rest stayed broken unnoticed |
| RC #10 | CI on PRs, the vendored branch, and Windows | same gap, other repo; its Windows job fails until RC #7 lands |
| MG #19 | `--opt-level`, default `-O2` | independent |
| MG #20 | Cache-domain affinity | independent |

Suggested order: **#18 and RC #7**, then RC #8, then MG #21; **MG #22 before MG
#23**. The rest are independent.

Verified on three platforms: Windows (MSVC + clang), Linux (g++ 15.2, x86_64) and
macOS 26.1 (clang, arm64). The portable pieces - the savestate layout and its
tests, `frontend_config`, `dol_patch` - build and pass on all three. Windows-only
pieces are guarded and their tests registered behind `if(WIN32)`.
