### PR TITLE
Add opt-in cache-domain affinity on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,17 +646,6 @@ if(BUILD_TESTING)
     target_compile_features(moderngekko_frontend_config_test PRIVATE cxx_std_23)
     add_test(NAME moderngekko.frontend_config COMMAND moderngekko_frontend_config_test)
 
-    if(WIN32)
-        # Header-only, and Windows-only like the rule it covers.
-        add_executable(moderngekko_cache_affinity_test
-            tests/cache_affinity_test.cpp)
-        target_include_directories(moderngekko_cache_affinity_test PRIVATE
-            "${CMAKE_CURRENT_SOURCE_DIR}/tools")
-        target_compile_features(moderngekko_cache_affinity_test PRIVATE cxx_std_23)
-        add_test(NAME moderngekko.cache_affinity
-                 COMMAND moderngekko_cache_affinity_test)
-    endif()
-
     add_executable(moderngekko_frontend_config_gamecube_test
         tests/frontend_config_test.cpp
         tools/frontend_config.cpp)
@@ -788,6 +777,17 @@ if(BUILD_TESTING)
     )
     add_test(NAME moderngekko.cpu_primitives
              COMMAND moderngekko_cpu_primitives_test)
+
+    if(WIN32)
+        # Header-only, and Windows-only like the rule it covers.
+        add_executable(moderngekko_cache_affinity_test
+            tests/cache_affinity_test.cpp)
+        target_include_directories(moderngekko_cache_affinity_test PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/tools")
+        target_compile_features(moderngekko_cache_affinity_test PRIVATE cxx_std_23)
+        add_test(NAME moderngekko.cache_affinity
+                 COMMAND moderngekko_cache_affinity_test)
+    endif()
 
     add_executable(moderngekko_address_space_test
         tests/address_space_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,6 +646,17 @@ if(BUILD_TESTING)
     target_compile_features(moderngekko_frontend_config_test PRIVATE cxx_std_23)
     add_test(NAME moderngekko.frontend_config COMMAND moderngekko_frontend_config_test)
 
+    if(WIN32)
+        # Header-only, and Windows-only like the rule it covers.
+        add_executable(moderngekko_cache_affinity_test
+            tests/cache_affinity_test.cpp)
+        target_include_directories(moderngekko_cache_affinity_test PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/tools")
+        target_compile_features(moderngekko_cache_affinity_test PRIVATE cxx_std_23)
+        add_test(NAME moderngekko.cache_affinity
+                 COMMAND moderngekko_cache_affinity_test)
+    endif()
+
     add_executable(moderngekko_frontend_config_gamecube_test
         tests/frontend_config_test.cpp
         tools/frontend_config.cpp)

--- a/tests/cache_affinity_test.cpp
+++ b/tests/cache_affinity_test.cpp
@@ -144,21 +144,18 @@ int main() {
       return 10;
   }
 
-  // --- the opt-out ---------------------------------------------------------
-  // Pinned down rather than left to be rediscovered from an inline condition:
-  // any value whose first character is neither NUL nor '0' disables pinning, so
-  // "false" turns it OFF.
+  // --- the opt-in ----------------------------------------------------------
   {
-    using moderngekko::frontend::AffinityDisabled;
-    if (AffinityDisabled(nullptr) || AffinityDisabled("") || AffinityDisabled("0"))
+    using moderngekko::frontend::AffinityEnabled;
+    if (AffinityEnabled(nullptr) || AffinityEnabled("") || AffinityEnabled("0"))
       return 11;
-    if (!AffinityDisabled("1") || !AffinityDisabled("true") || !AffinityDisabled("false"))
+    if (!AffinityEnabled("1") || AffinityEnabled("true") || AffinityEnabled("10"))
       return 12;
   }
 
   // --- the Win32 calls themselves ------------------------------------------
   // Applied to this process and read back out of the OS, so the test observes
-  // what actually happened rather than that two functions were called.
+  // what actually happened rather than merely trusting the return value.
   {
     using moderngekko::frontend::ApplyCacheDomain;
     const HANDLE self = GetCurrentProcess();
@@ -166,8 +163,6 @@ int main() {
     DWORD_PTR system_affinity = 0;
     if (!GetProcessAffinityMask(self, &original_affinity, &system_affinity))
       return 13;
-    const DWORD original_priority = GetPriorityClass(self);
-
     // The lowest core this process is already allowed on: a mask has to be a
     // subset of the process's current affinity or the call fails.
     const KAFFINITY subset = original_affinity & (~original_affinity + 1);
@@ -177,29 +172,24 @@ int main() {
     DWORD_PTR applied = 0;
     DWORD_PTR ignored = 0;
     GetProcessAffinityMask(self, &applied, &ignored);
-    const DWORD priority = GetPriorityClass(self);
-
-    // Restore before reporting, so a failure here does not leave the rest of
-    // the suite pinned to one core at high priority.
+    // Restore before reporting, so a failure does not leave the rest of the
+    // suite pinned to one core.
     SetProcessAffinityMask(self, original_affinity);
-    SetPriorityClass(self, original_priority);
 
     if (!result.affinity_set || applied != subset)
       return 14;
-    if (!result.priority_raised || priority != HIGH_PRIORITY_CLASS)
-      return 15;
 
     DWORD_PTR restored = 0;
     GetProcessAffinityMask(self, &restored, &ignored);
-    if (restored != original_affinity || GetPriorityClass(self) != original_priority)
-      return 16;
+    if (restored != original_affinity)
+      return 15;
 
     // An empty domain must leave the process alone rather than pin it to
     // nothing: there was simply no L3 to find.
     const auto none = ApplyCacheDomain(self, CacheDomain{});
     GetProcessAffinityMask(self, &applied, &ignored);
-    if (none.affinity_set || none.priority_raised || applied != original_affinity)
-      return 17;
+    if (none.affinity_set || applied != original_affinity)
+      return 16;
   }
 
   return 0;

--- a/tests/cache_affinity_test.cpp
+++ b/tests/cache_affinity_test.cpp
@@ -144,5 +144,63 @@ int main() {
       return 10;
   }
 
+  // --- the opt-out ---------------------------------------------------------
+  // Pinned down rather than left to be rediscovered from an inline condition:
+  // any value whose first character is neither NUL nor '0' disables pinning, so
+  // "false" turns it OFF.
+  {
+    using moderngekko::frontend::AffinityDisabled;
+    if (AffinityDisabled(nullptr) || AffinityDisabled("") || AffinityDisabled("0"))
+      return 11;
+    if (!AffinityDisabled("1") || !AffinityDisabled("true") || !AffinityDisabled("false"))
+      return 12;
+  }
+
+  // --- the Win32 calls themselves ------------------------------------------
+  // Applied to this process and read back out of the OS, so the test observes
+  // what actually happened rather than that two functions were called.
+  {
+    using moderngekko::frontend::ApplyCacheDomain;
+    const HANDLE self = GetCurrentProcess();
+    DWORD_PTR original_affinity = 0;
+    DWORD_PTR system_affinity = 0;
+    if (!GetProcessAffinityMask(self, &original_affinity, &system_affinity))
+      return 13;
+    const DWORD original_priority = GetPriorityClass(self);
+
+    // The lowest core this process is already allowed on: a mask has to be a
+    // subset of the process's current affinity or the call fails.
+    const KAFFINITY subset = original_affinity & (~original_affinity + 1);
+    const CacheDomain domain{subset, 96 * MB};
+
+    const auto result = ApplyCacheDomain(self, domain);
+    DWORD_PTR applied = 0;
+    DWORD_PTR ignored = 0;
+    GetProcessAffinityMask(self, &applied, &ignored);
+    const DWORD priority = GetPriorityClass(self);
+
+    // Restore before reporting, so a failure here does not leave the rest of
+    // the suite pinned to one core at high priority.
+    SetProcessAffinityMask(self, original_affinity);
+    SetPriorityClass(self, original_priority);
+
+    if (!result.affinity_set || applied != subset)
+      return 14;
+    if (!result.priority_raised || priority != HIGH_PRIORITY_CLASS)
+      return 15;
+
+    DWORD_PTR restored = 0;
+    GetProcessAffinityMask(self, &restored, &ignored);
+    if (restored != original_affinity || GetPriorityClass(self) != original_priority)
+      return 16;
+
+    // An empty domain must leave the process alone rather than pin it to
+    // nothing: there was simply no L3 to find.
+    const auto none = ApplyCacheDomain(self, CacheDomain{});
+    GetProcessAffinityMask(self, &applied, &ignored);
+    if (none.affinity_set || none.priority_raised || applied != original_affinity)
+      return 17;
+  }
+
   return 0;
 }

--- a/tests/cache_affinity_test.cpp
+++ b/tests/cache_affinity_test.cpp
@@ -1,0 +1,148 @@
+// The layouts that matter here cannot be produced on demand by whatever machine
+// runs the tests -- a part with 3D V-Cache on one die only, a part where every
+// core shares a single cache -- so the buffer the OS would return is built by
+// hand and the selection rule is checked against it.
+#include "cache_affinity.hpp"
+
+#include <cstring>
+#include <vector>
+
+namespace {
+using moderngekko::frontend::CacheDomain;
+using moderngekko::frontend::LargestSharedCache;
+
+// One RelationCache record, laid out exactly as GetLogicalProcessorInformationEx
+// returns it.
+void AppendCache(std::vector<char> &buffer, BYTE level, DWORD size_bytes, KAFFINITY mask) {
+  SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX entry{};
+  entry.Relationship = RelationCache;
+  entry.Size = sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX);
+  entry.Cache.Level = level;
+  entry.Cache.CacheSize = size_bytes;
+  entry.Cache.Type = CacheUnified;
+  entry.Cache.GroupMask.Mask = mask;
+  entry.Cache.GroupMask.Group = 0;
+  const std::size_t at = buffer.size();
+  buffer.resize(at + entry.Size);
+  std::memcpy(buffer.data() + at, &entry, entry.Size);
+}
+
+// A record of some other relationship, which must be skipped rather than
+// misread as a cache.
+void AppendNonCache(std::vector<char> &buffer) {
+  SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX entry{};
+  entry.Relationship = RelationProcessorCore;
+  entry.Size = sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX);
+  const std::size_t at = buffer.size();
+  buffer.resize(at + entry.Size);
+  std::memcpy(buffer.data() + at, &entry, entry.Size);
+}
+
+constexpr DWORD MB = 1024 * 1024;
+} // namespace
+
+int main() {
+  // A 9950X3D-shaped part: two CCDs, 3D V-Cache on one. The rule must choose the
+  // stacked die, which is the whole point of the change.
+  {
+    std::vector<char> buffer;
+    AppendCache(buffer, 1, 32 * 1024, 0x0003);
+    AppendCache(buffer, 2, 1 * MB, 0x00FF);
+    AppendCache(buffer, 3, 96 * MB, 0xFFFF);         // V-Cache die
+    AppendCache(buffer, 3, 32 * MB, 0xFFFF0000ULL);  // plain die
+    const CacheDomain domain = LargestSharedCache(buffer.data(), buffer.size());
+    if (!domain || domain.mask != 0xFFFF || domain.size != 96 * MB)
+      return 1;
+  }
+
+  // Reported in the other order, the answer must not change.
+  {
+    std::vector<char> buffer;
+    AppendCache(buffer, 3, 32 * MB, 0xFFFF0000ULL);
+    AppendCache(buffer, 3, 96 * MB, 0xFFFF);
+    const CacheDomain domain = LargestSharedCache(buffer.data(), buffer.size());
+    if (!domain || domain.mask != 0xFFFF)
+      return 2;
+  }
+
+  // A part where every core shares one L3: the mask covers all of them, so
+  // pinning to it is a no-op rather than a restriction. This is what keeps the
+  // change correct on hardware without a V-Cache die.
+  {
+    std::vector<char> buffer;
+    AppendCache(buffer, 3, 32 * MB, 0xFFFFFFFFULL);
+    const CacheDomain domain = LargestSharedCache(buffer.data(), buffer.size());
+    if (!domain || domain.mask != 0xFFFFFFFFULL)
+      return 3;
+  }
+
+  // Equal sizes keep the first match, so the result does not depend on the order
+  // the OS happens to report caches in.
+  {
+    std::vector<char> buffer;
+    AppendCache(buffer, 3, 32 * MB, 0x00FF);
+    AppendCache(buffer, 3, 32 * MB, 0xFF00);
+    const CacheDomain domain = LargestSharedCache(buffer.data(), buffer.size());
+    if (domain.mask != 0x00FF)
+      return 4;
+  }
+
+  // Only the requested level counts. A machine with no L3 at all yields nothing
+  // to pin to, and the caller must leave affinity alone rather than pin to an L2.
+  {
+    std::vector<char> buffer;
+    AppendCache(buffer, 1, 64 * 1024, 0x0003);
+    AppendCache(buffer, 2, 8 * MB, 0x00FF);
+    const CacheDomain domain = LargestSharedCache(buffer.data(), buffer.size());
+    if (domain)
+      return 5;
+    // Asking for L2 explicitly still works.
+    const CacheDomain l2 = LargestSharedCache(buffer.data(), buffer.size(), 2);
+    if (!l2 || l2.mask != 0x00FF)
+      return 6;
+  }
+
+  // Records of other relationships are skipped, not misread.
+  {
+    std::vector<char> buffer;
+    AppendNonCache(buffer);
+    AppendCache(buffer, 3, 96 * MB, 0x00FF);
+    AppendNonCache(buffer);
+    const CacheDomain domain = LargestSharedCache(buffer.data(), buffer.size());
+    if (!domain || domain.mask != 0x00FF)
+      return 7;
+  }
+
+  // An empty buffer is not an error; there is simply nothing to pin to.
+  if (LargestSharedCache(nullptr, 0))
+    return 8;
+
+  // A record claiming Size 0 would never advance the cursor. The scan must stop
+  // instead of spinning forever, and keep whatever it found before it.
+  {
+    std::vector<char> buffer;
+    AppendCache(buffer, 3, 96 * MB, 0x00FF);
+    auto *second = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *>(
+        buffer.data() + buffer.size());
+    buffer.resize(buffer.size() + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX));
+    second = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *>(
+        buffer.data() + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX));
+    std::memset(second, 0, sizeof(*second));
+    second->Relationship = RelationCache;
+    second->Size = 0;
+    const CacheDomain domain = LargestSharedCache(buffer.data(), buffer.size());
+    if (!domain || domain.mask != 0x00FF)
+      return 9;
+  }
+
+  // A buffer that ends mid-record must not be read past its end.
+  {
+    std::vector<char> buffer;
+    AppendCache(buffer, 3, 96 * MB, 0x00FF);
+    const CacheDomain domain = LargestSharedCache(buffer.data(), buffer.size() - 8);
+    if (domain)
+      return 10;
+  }
+
+  return 0;
+}

--- a/tools/cache_affinity.hpp
+++ b/tools/cache_affinity.hpp
@@ -61,5 +61,37 @@ inline CacheDomain LargestSharedCache(const void* records, std::size_t bytes, BY
   }
   return best;
 }
+
+// The opt-out, split out so its exact acceptance can be pinned down. Any value
+// whose first character is neither NUL nor '0' disables pinning -- so "0" and an
+// empty value leave it on, and anything else, including "false", turns it off.
+// That is the behaviour this shipped with; it is spelled out here rather than
+// left to be rediscovered from an inline condition.
+inline bool AffinityDisabled(const char* value)
+{
+  return value != nullptr && value[0] != '\0' && value[0] != '0';
+}
+
+struct PinResult
+{
+  bool affinity_set = false;
+  bool priority_raised = false;
+};
+
+// Applies a domain to a process. Separate from choosing one so a test can hand
+// it a real process handle and read the result back out of the OS, rather than
+// taking on trust that the two calls were made.
+//
+// An empty domain is not an error: there was nothing to pin to, and the
+// process's existing affinity is left alone.
+inline PinResult ApplyCacheDomain(HANDLE process, const CacheDomain& domain)
+{
+  PinResult result;
+  if (!domain)
+    return result;
+  result.affinity_set = SetProcessAffinityMask(process, domain.mask) != FALSE;
+  result.priority_raised = SetPriorityClass(process, HIGH_PRIORITY_CLASS) != FALSE;
+  return result;
+}
 }  // namespace moderngekko::frontend
 #endif  // _WIN32

--- a/tools/cache_affinity.hpp
+++ b/tools/cache_affinity.hpp
@@ -62,25 +62,20 @@ inline CacheDomain LargestSharedCache(const void* records, std::size_t bytes, BY
   return best;
 }
 
-// The opt-out, split out so its exact acceptance can be pinned down. Any value
-// whose first character is neither NUL nor '0' disables pinning -- so "0" and an
-// empty value leave it on, and anything else, including "false", turns it off.
-// That is the behaviour this shipped with; it is spelled out here rather than
-// left to be rediscovered from an inline condition.
-inline bool AffinityDisabled(const char* value)
+// Process-wide affinity can interfere with Dolphin's worker threads, so require
+// an exact, explicit opt-in instead of changing every launch by default.
+inline bool AffinityEnabled(const char* value)
 {
-  return value != nullptr && value[0] != '\0' && value[0] != '0';
+  return value != nullptr && value[0] == '1' && value[1] == '\0';
 }
 
 struct PinResult
 {
   bool affinity_set = false;
-  bool priority_raised = false;
 };
 
 // Applies a domain to a process. Separate from choosing one so a test can hand
-// it a real process handle and read the result back out of the OS, rather than
-// taking on trust that the two calls were made.
+// it a real process handle and read the result back out of the OS.
 //
 // An empty domain is not an error: there was nothing to pin to, and the
 // process's existing affinity is left alone.
@@ -90,7 +85,6 @@ inline PinResult ApplyCacheDomain(HANDLE process, const CacheDomain& domain)
   if (!domain)
     return result;
   result.affinity_set = SetProcessAffinityMask(process, domain.mask) != FALSE;
-  result.priority_raised = SetPriorityClass(process, HIGH_PRIORITY_CLASS) != FALSE;
   return result;
 }
 }  // namespace moderngekko::frontend

--- a/tools/cache_affinity.hpp
+++ b/tools/cache_affinity.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+// Which cores share the largest cache at a given level.
+//
+// Split out from the pinning itself so the rule can be tested against a
+// synthetic topology: the interesting layouts -- a part with 3D V-Cache on one
+// die only, a part where every core shares one cache -- cannot be produced on
+// demand by the machine running the tests, and the rule is the part that decides
+// whether the pin helps or does nothing.
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
+namespace moderngekko::frontend
+{
+struct CacheDomain
+{
+  KAFFINITY mask = 0;
+  DWORD size = 0;
+
+  // A zero mask means nothing matched, so there is nothing to pin to.
+  explicit operator bool() const { return mask != 0; }
+};
+
+// Scans a GetLogicalProcessorInformationEx(RelationCache, ...) buffer.
+//
+// Ties keep the first match rather than the last, so the answer does not depend
+// on the order the OS happens to report caches in.
+//
+// Multi-group machines would need every group considered; a single group covers
+// up to 64 logical processors, which is all this targets.
+inline CacheDomain LargestSharedCache(const void* records, std::size_t bytes, BYTE level = 3)
+{
+  CacheDomain best;
+  const auto* base = static_cast<const char*>(records);
+  for (std::size_t offset = 0;
+       offset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) <= bytes;)
+  {
+    const auto* entry =
+        reinterpret_cast<const SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*>(base + offset);
+    // A zero Size would not advance, so this stops rather than spinning on a
+    // truncated or malformed buffer.
+    if (entry->Size == 0)
+      break;
+    if (entry->Relationship == RelationCache && entry->Cache.Level == level &&
+        entry->Cache.CacheSize > best.size)
+    {
+      best.size = entry->Cache.CacheSize;
+      best.mask = entry->Cache.GroupMask.Mask;
+    }
+    offset += entry->Size;
+  }
+  return best;
+}
+}  // namespace moderngekko::frontend
+#endif  // _WIN32

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -16,6 +16,15 @@
 #include <thread>
 #include <vector>
 
+#if defined(_WIN32)
+// For the affinity/priority setup in main(). WIN32_LEAN_AND_MEAN keeps the
+// winsock and GDI surface out of a translation unit that only needs the
+// processor-topology and process calls.
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 namespace {
 #ifndef MODERNGEKKO_RUNNER_NAME
 #define MODERNGEKKO_RUNNER_NAME "moderngekko-run"
@@ -386,8 +395,69 @@ int RunMain(int argc, char **argv) {
   return 0;
 }
 
+#if defined(_WIN32)
+// Confine the process to the cores that share the largest L3, and raise its
+// priority.
+//
+// The emulated CPU is a single serial instruction stream, so nothing here is
+// about parallelism -- core usage stays at 1.00 either way. It is about cache
+// residency. A recompiled module is one dispatch switch spanning the whole
+// game, which lives or dies on staying in L3, and on a chip with 3D V-Cache on
+// one CCD only, Windows migrating the thread between dies makes it repeatedly
+// lose its working set. Measured on a 9950X3D: 55.41 -> 70.42 fps, +27%.
+//
+// Selecting by "largest L3" rather than a hardcoded mask keeps this correct
+// elsewhere: where every core shares one L3 the mask covers all of them and
+// this is a no-op. Set MODERNGEKKO_NO_AFFINITY=1 to skip it entirely.
+void PinToLargestCache() {
+  if (const char *disabled = std::getenv("MODERNGEKKO_NO_AFFINITY");
+      disabled && disabled[0] && disabled[0] != '0')
+    return;
+
+  DWORD length = 0;
+  GetLogicalProcessorInformationEx(RelationCache, nullptr, &length);
+  if (length == 0)
+    return;
+  std::vector<char> buffer(length);
+  if (!GetLogicalProcessorInformationEx(
+          RelationCache,
+          reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(buffer.data()), &length))
+    return;
+
+  KAFFINITY best_mask = 0;
+  DWORD best_size = 0;
+  for (DWORD offset = 0; offset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) <= length;) {
+    auto *entry =
+        reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(buffer.data() + offset);
+    if (entry->Size == 0)
+      break;
+    if (entry->Relationship == RelationCache && entry->Cache.Level == 3 &&
+        entry->Cache.CacheSize > best_size) {
+      // Multi-group machines would need every group considered; a single group
+      // covers up to 64 logical processors, which is all this targets.
+      best_size = entry->Cache.CacheSize;
+      best_mask = entry->Cache.GroupMask.Mask;
+    }
+    offset += entry->Size;
+  }
+  if (best_mask == 0)
+    return;
+
+  const HANDLE process = GetCurrentProcess();
+  if (SetProcessAffinityMask(process, best_mask)) {
+    std::cout << "[perf] pinned to the cores sharing the largest L3 (" << (best_size >> 20)
+              << " MB), mask 0x" << std::hex << static_cast<unsigned long long>(best_mask)
+              << std::dec << '\n';
+  }
+  SetPriorityClass(process, HIGH_PRIORITY_CLASS);
+}
+#endif
+
 int main(int argc, char **argv) {
   try {
+#if defined(_WIN32)
+    PinToLargestCache();
+#endif
     return RunMain(argc, argv);
   } catch (const std::exception &error) {
     std::cerr << "fatal error: " << error.what() << '\n';

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -397,8 +397,7 @@ int RunMain(int argc, char **argv) {
 }
 
 #if defined(_WIN32)
-// Confine the process to the cores that share the largest L3, and raise its
-// priority.
+// Optionally confine the process to the cores that share the largest L3.
 //
 // The emulated CPU is a single serial instruction stream, so nothing here is
 // about parallelism -- core usage stays at 1.00 either way. It is about cache
@@ -407,11 +406,12 @@ int RunMain(int argc, char **argv) {
 // one CCD only, Windows migrating the thread between dies makes it repeatedly
 // lose its working set. Measured on a 9950X3D: 55.41 -> 70.42 fps, +27%.
 //
-// Selecting by "largest L3" rather than a hardcoded mask keeps this correct
-// elsewhere: where every core shares one L3 the mask covers all of them and
-// this is a no-op. Set MODERNGEKKO_NO_AFFINITY=1 to skip it entirely.
-void PinToLargestCache() {
-  if (moderngekko::frontend::AffinityDisabled(std::getenv("MODERNGEKKO_NO_AFFINITY")))
+// This applies to every Dolphin thread, not only the emulated CPU thread, so it
+// is opt-in. Set MODERNGEKKO_CACHE_AFFINITY=1 to enable it after benchmarking
+// the target machine.
+void PinProcessToLargestCache() {
+  if (!moderngekko::frontend::AffinityEnabled(
+          std::getenv("MODERNGEKKO_CACHE_AFFINITY")))
     return;
 
   DWORD length = 0;
@@ -440,7 +440,7 @@ void PinToLargestCache() {
 int main(int argc, char **argv) {
   try {
 #if defined(_WIN32)
-    PinToLargestCache();
+    PinProcessToLargestCache();
 #endif
     return RunMain(argc, argv);
   } catch (const std::exception &error) {

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -1,3 +1,4 @@
+#include "cache_affinity.hpp"
 #include "frontend_config.hpp"
 #include "dol_patch.hpp"
 #include "moderngekko/game.hpp"
@@ -424,29 +425,15 @@ void PinToLargestCache() {
           reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(buffer.data()), &length))
     return;
 
-  KAFFINITY best_mask = 0;
-  DWORD best_size = 0;
-  for (DWORD offset = 0; offset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) <= length;) {
-    auto *entry =
-        reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(buffer.data() + offset);
-    if (entry->Size == 0)
-      break;
-    if (entry->Relationship == RelationCache && entry->Cache.Level == 3 &&
-        entry->Cache.CacheSize > best_size) {
-      // Multi-group machines would need every group considered; a single group
-      // covers up to 64 logical processors, which is all this targets.
-      best_size = entry->Cache.CacheSize;
-      best_mask = entry->Cache.GroupMask.Mask;
-    }
-    offset += entry->Size;
-  }
-  if (best_mask == 0)
+  const moderngekko::frontend::CacheDomain domain =
+      moderngekko::frontend::LargestSharedCache(buffer.data(), length);
+  if (!domain)
     return;
 
   const HANDLE process = GetCurrentProcess();
-  if (SetProcessAffinityMask(process, best_mask)) {
-    std::cout << "[perf] pinned to the cores sharing the largest L3 (" << (best_size >> 20)
-              << " MB), mask 0x" << std::hex << static_cast<unsigned long long>(best_mask)
+  if (SetProcessAffinityMask(process, domain.mask)) {
+    std::cout << "[perf] pinned to the cores sharing the largest L3 (" << (domain.size >> 20)
+              << " MB), mask 0x" << std::hex << static_cast<unsigned long long>(domain.mask)
               << std::dec << '\n';
   }
   SetPriorityClass(process, HIGH_PRIORITY_CLASS);

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -411,8 +411,7 @@ int RunMain(int argc, char **argv) {
 // elsewhere: where every core shares one L3 the mask covers all of them and
 // this is a no-op. Set MODERNGEKKO_NO_AFFINITY=1 to skip it entirely.
 void PinToLargestCache() {
-  if (const char *disabled = std::getenv("MODERNGEKKO_NO_AFFINITY");
-      disabled && disabled[0] && disabled[0] != '0')
+  if (moderngekko::frontend::AffinityDisabled(std::getenv("MODERNGEKKO_NO_AFFINITY")))
     return;
 
   DWORD length = 0;
@@ -430,13 +429,11 @@ void PinToLargestCache() {
   if (!domain)
     return;
 
-  const HANDLE process = GetCurrentProcess();
-  if (SetProcessAffinityMask(process, domain.mask)) {
+  if (moderngekko::frontend::ApplyCacheDomain(GetCurrentProcess(), domain).affinity_set) {
     std::cout << "[perf] pinned to the cores sharing the largest L3 (" << (domain.size >> 20)
               << " MB), mask 0x" << std::hex << static_cast<unsigned long long>(domain.mask)
               << std::dec << '\n';
   }
-  SetPriorityClass(process, HIGH_PRIORITY_CLASS);
 }
 #endif
 


### PR DESCRIPTION
> **Maintainer update:** This now applies process-wide affinity only when `MODERNGEKKO_CACHE_AFFINITY=1` is set. The unconditional high-priority change was removed.

A recompiled module is one dispatch switch spanning the whole game, so it lives or dies on instruction-cache residency. On a multi-CCD part the OS migrates the emulator thread between complexes and a quarter of the frame rate goes with it.

Measured on Mario Kart: Double Dash!!, same module and savestate, frame limiter off, on a 9950X3D:

| | speed | fps |
|---|---|---|
| pinned to the cores sharing the largest L3 | 1.1696 / 1.1802 | **70.42** |
| default affinity | 0.9139 / 0.9351 | 55.41 |

Core usage stayed at exactly 1.00 in both, so this is cache locality rather than parallelism. It needs no rebuild of the module.

The selection rule is "the cores sharing the largest L3", read from the topology rather than a hardcoded mask, so it is correct by construction on parts without a V-Cache die and a no-op where every core shares one L3. `MODERNGEKKO_NO_AFFINITY=1` skips it.

Windows only for now. The Linux equivalent is direct — topology from `/sys/devices/system/cpu/cpu*/cache/index*/` and `sched_setaffinity(2)` — and macOS has no equivalent API, so both fall through unchanged.

## Validated across five games

Uncapped, three alternating runs per arm, metric is frames presented per real second, median reported. On this host the rule selected mask `0xffff` — the 16 logical processors sharing the 96 MB L3 of the V-Cache die.

| Game | default | pinned | |
|---|---|---|---|
| Mario Kart: Double Dash!! | 55.41 | **70.42** | **+27.1%** |
| Mario Kart: Double Dash!! (re-measured, split-screen) | 64.70 | **77.34** | **+19.6%** |
| The Legend of Zelda: Skyward Sword | 31.05 | **40.86** | **+31.6%** |
| Luigi's Mansion | 46.61 | **55.00** | **+18.0%** |
| Paper Mario: The Thousand-Year Door | 89.32 | **102.23** | **+14.5%** |
| Pokémon Colosseum | 65.53 | **73.53** | **+12.2%** |

Every title gains, across a Wii title and four GameCube ones, and across runtimes built from four separate trees.

### Method, and the two silent failure modes it guards against

The patched runtime exists only in one project's tree, and a runtime can only host a module built by the same tree, so the patched binary cannot simply be pointed at the other games. What the patch does is not privileged — confine the process to the cores sharing the largest L3 and raise its priority — so for the four cross-checks the identical two Win32 calls were applied from outside to each game's own runtime, immediately after spawn and long before boot. The mask was not guessed: it is the mask this patch selected and logged.

As a control, Colosseum was also measured the other way, using the patch's own binary with `MODERNGEKKO_NO_AFFINITY=1` as the "default" arm, so both arms are the same executable and nothing but the pin differs. That read **+11.1%** (32.68 vs 29.41, sd 0.11 / 0.21) against **+7.8%** for the external pin — consistent, and the patched binary is not flattering itself. Both of those predate the correction below and were taken on the same modified disc, so treat them as a check that the two methods agree with each other rather than as figures for a stock game.

Two checks, because both failure modes are silent. The pinned arm logs `[perf] pinned` and the unpinned arm does not, on every run; otherwise a skipped pin reads as "no difference". And every scene was screenshotted mid-run to confirm the savestate actually loaded — `--load-state` is accepted and then ignored when it does not match the binary that wrote it, which would quietly measure a boot logo instead.

### One caveat on magnitudes

The four cross-game runs were taken while a remote-desktop session was encoding every frame, which makes them partly present-bound and compresses CPU-side wins. The control for that is the dispatch fast path, whose magnitude is independently known: on the same host in the same session it read **+10.8%**, against **+31.8%** measured on the same game, module and savestate when the host was clean. So these figures are floors rather than best cases — the direction and the ordering are the durable result, not the exact percentages. Paper Mario's scene is a cutscene rather than gameplay; the other four are gameplay.

Multi-group machines would need every processor group considered; a single group covers 64 logical processors, which is all this targets.

### Testing the selection rule

Which cores share the largest L3 is what decides whether this helps or does nothing, and it was inline with the Win32 calls that apply it — so it could only ever be exercised on whatever machine ran it, for that machine's topology. `LargestSharedCache` now takes the buffer and returns the domain, so `tests/cache_affinity_test.cpp` builds the layouts that matter by hand:

- a part with 3D V-Cache on one die only — the rule must pick the stacked die
- **a part where every core shares one L3** — the mask covers all of them, so pinning is a no-op. This is the case that keeps the change correct on hardware without a V-Cache die, and it was previously untestable
- ties keep the first match, so the answer does not depend on the order the OS reports caches in
- only the requested level counts, so a machine with no L3 yields nothing to pin to rather than pinning to an L2
- non-cache relationship records are skipped rather than misread
- a record claiming `Size 0` stops the scan instead of spinning on it, and a truncated buffer is not read past its end

Checked that the test is load-bearing by mutating what it guards: making ties take the last match fails it (exit 4), and dropping the level check fails it (exit 5).

No behaviour change — the same records are examined in the same order. The Win32 calls themselves stay untested; the rule does not have to be.

### One figure was corrected after publication

The Colosseum row originally read 30.49 -> 32.86 (+7.8%). Those runs were measuring a **modified game**, and it took a failing test to notice.

A runtime built with `MODERNGEKKO_DOL_PATCH_MANIFEST` rewrites `<game_root>/sys/main.dol` **in place on every boot**, applying whatever manifest was baked in at build time. For the branded Colosseum arms that manifest is a native-widescreen patch, so the first bench run converted the disc to 32:9 and every run after it measured an ultrawide game at 5x internal quality. That is why the absolutes were ~30 fps rather than ~65.

Re-measured against a pristine disc, held by the harness rather than by any project, with the DOL hashed before and after to prove it stayed untouched: **65.53 -> 73.53, +12.2%**, on the Outskirt Stand in 4:3.

The delta survived the mistake because both arms were equally patched, which is exactly why an A/B is worth more than an absolute. The absolute did not.

Worth flagging for its own sake: patching the disc in place on every boot, with no opt-out, is a sharp edge. A `--no-dol-patch` flag, or patching a copy, would make it impossible to measure a game you did not mean to modify.

### How this fits

These land together as a set: savestates working end to end, the Windows build
and test suite being usable at all, and CI so none of it regresses unnoticed.
**This PR is MG #20.**

| | | |
|---|---|---|
| MG #18 | Bump vendored RecompCore | **prerequisite** - without it the launcher cannot compile on Windows (C sources get a C++ PCH) |
| RC #7 | `Interpreter.cpp` include | **prerequisite** - `core` does not compile without it |
| RC #8 | In-game File/View menu and hotkeys | introduces `Core/SavestateLayout.h`, the one definition of where savestates live, what they are called and how they are ordered |
| MG #21 | Launcher savestate picker, `--load-state` | consumes that header, so the launcher and the in-game menu cannot disagree |
| MG #22 | Make the test suite pass on Windows | **land before CI**, or the first run is red on day one |
| MG #23 | Build and test on PRs, three platforms | the reason the rest stayed broken unnoticed |
| RC #10 | CI on PRs, the vendored branch, and Windows | same gap, other repo; its Windows job fails until RC #7 lands |
| MG #19 | `--opt-level`, default `-O2` | independent |
| MG #20 | Cache-domain affinity | independent |

Suggested order: **#18 and RC #7**, then RC #8, then MG #21; **MG #22 before MG
#23**. The rest are independent.

Verified on three platforms: Windows (MSVC + clang), Linux (g++ 15.2, x86_64) and
macOS 26.1 (clang, arm64). The portable pieces - the savestate layout and its
tests, `frontend_config`, `dol_patch` - build and pass on all three. Windows-only
pieces are guarded and their tests registered behind `if(WIN32)`.
