### PR TITLE
Let the launcher start a game from a savestate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,7 +650,10 @@ if(BUILD_TESTING)
     add_executable(moderngekko_launcher_savestates_test
         tests/launcher_savestates_test.cpp)
     target_include_directories(moderngekko_launcher_savestates_test PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/tools")
+        "${CMAKE_CURRENT_SOURCE_DIR}/tools"
+        # For Core/SavestateLayout.h, which owns the listing rules. It depends on
+        # nothing but the standard library, so this pulls in no Dolphin linkage.
+        "${CMAKE_CURRENT_SOURCE_DIR}/vendor/dolphin/Source/Core")
     target_compile_features(moderngekko_launcher_savestates_test PRIVATE cxx_std_23)
     add_test(NAME moderngekko.launcher_savestates
              COMMAND moderngekko_launcher_savestates_test)
@@ -700,6 +703,21 @@ if(BUILD_TESTING)
         else()
             target_link_libraries(moderngekko_netplay_protocol_test PRIVATE
                 ModernGekko::Runtime core uicommon)
+        endif()
+        if(WIN32)
+            # The same treatment the non-test Windows targets get from the loop
+            # above, which runs before the test targets exist and so misses
+            # them. WIN32_LEAN_AND_MEAN keeps windows.h from pulling in
+            # winsock.h, which would clash with the winsock2.h this reaches
+            # through Dolphin's networking headers ('sockaddr' redefinition).
+            target_compile_definitions(moderngekko_netplay_protocol_test PRIVATE
+                WIN32_LEAN_AND_MEAN NOMINMAX)
+            if(MSVC)
+                # Dolphin's headers use __VA_OPT__, which the traditional
+                # preprocessor cannot parse.
+                target_compile_options(moderngekko_netplay_protocol_test PRIVATE
+                    /Zc:preprocessor)
+            endif()
         endif()
         add_test(NAME moderngekko.netplay_protocol COMMAND moderngekko_netplay_protocol_test)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,6 +646,15 @@ if(BUILD_TESTING)
     target_compile_features(moderngekko_frontend_config_test PRIVATE cxx_std_23)
     add_test(NAME moderngekko.frontend_config COMMAND moderngekko_frontend_config_test)
 
+    # Header-only, so the test needs no companion translation unit.
+    add_executable(moderngekko_launcher_savestates_test
+        tests/launcher_savestates_test.cpp)
+    target_include_directories(moderngekko_launcher_savestates_test PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/tools")
+    target_compile_features(moderngekko_launcher_savestates_test PRIVATE cxx_std_23)
+    add_test(NAME moderngekko.launcher_savestates
+             COMMAND moderngekko_launcher_savestates_test)
+
     add_executable(moderngekko_frontend_config_gamecube_test
         tests/frontend_config_test.cpp
         tools/frontend_config.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -704,21 +704,6 @@ if(BUILD_TESTING)
             target_link_libraries(moderngekko_netplay_protocol_test PRIVATE
                 ModernGekko::Runtime core uicommon)
         endif()
-        if(WIN32)
-            # The same treatment the non-test Windows targets get from the loop
-            # above, which runs before the test targets exist and so misses
-            # them. WIN32_LEAN_AND_MEAN keeps windows.h from pulling in
-            # winsock.h, which would clash with the winsock2.h this reaches
-            # through Dolphin's networking headers ('sockaddr' redefinition).
-            target_compile_definitions(moderngekko_netplay_protocol_test PRIVATE
-                WIN32_LEAN_AND_MEAN NOMINMAX)
-            if(MSVC)
-                # Dolphin's headers use __VA_OPT__, which the traditional
-                # preprocessor cannot parse.
-                target_compile_options(moderngekko_netplay_protocol_test PRIVATE
-                    /Zc:preprocessor)
-            endif()
-        endif()
         add_test(NAME moderngekko.netplay_protocol COMMAND moderngekko_netplay_protocol_test)
     endif()
 

--- a/include/moderngekko/runtime.hpp
+++ b/include/moderngekko/runtime.hpp
@@ -66,6 +66,8 @@ struct RuntimeConfig
   bool allow_interpreter = false;
   bool show_fps_in_title = true;
   std::optional<std::string> window_title;
+  // Boot straight into a savestate instead of from the title screen.
+  std::optional<std::filesystem::path> load_state_path;
 };
 
 enum class RuntimeErrorCode

--- a/src/runtime/dolphin_runtime.cpp
+++ b/src/runtime/dolphin_runtime.cpp
@@ -359,6 +359,13 @@ RuntimeRunResult Runtime::Run() {
     if (s_boot_session_data)
       boot = BootParameters::GenerateFromFile(
           m_impl->metadata.main_dol.string(), std::move(*s_boot_session_data));
+    else if (m_impl->config.load_state_path)
+      // DeleteSavestateAfterBoot::No: the state is the player's, not a
+      // scratch file this run owns.
+      boot = BootParameters::GenerateFromFile(
+          m_impl->metadata.main_dol.string(),
+          BootSessionData(m_impl->config.load_state_path->string(),
+                          DeleteSavestateAfterBoot::No));
     else
       boot =
           BootParameters::GenerateFromFile(m_impl->metadata.main_dol.string());

--- a/src/runtime/dolphin_runtime.cpp
+++ b/src/runtime/dolphin_runtime.cpp
@@ -3,6 +3,7 @@
 #include "AudioCommon/AudioCommon.h"
 #include "Common/Config/Config.h"
 #include "Common/HookableEvent.h"
+#include "Common/StringUtil.h"
 #include "Core/Boot/Boot.h"
 #include "Core/Boot/BootManager.h"
 #include "Core/Config/GraphicsSettings.h"
@@ -358,17 +359,17 @@ RuntimeRunResult Runtime::Run() {
     std::lock_guard lock(s_runtime_mutex);
     if (s_boot_session_data)
       boot = BootParameters::GenerateFromFile(
-          m_impl->metadata.main_dol.string(), std::move(*s_boot_session_data));
+          PathToString(m_impl->metadata.main_dol), std::move(*s_boot_session_data));
     else if (m_impl->config.load_state_path)
       // DeleteSavestateAfterBoot::No: the state is the player's, not a
       // scratch file this run owns.
       boot = BootParameters::GenerateFromFile(
-          m_impl->metadata.main_dol.string(),
-          BootSessionData(m_impl->config.load_state_path->string(),
+          PathToString(m_impl->metadata.main_dol),
+          BootSessionData(PathToString(*m_impl->config.load_state_path),
                           DeleteSavestateAfterBoot::No));
     else
       boot =
-          BootParameters::GenerateFromFile(m_impl->metadata.main_dol.string());
+          BootParameters::GenerateFromFile(PathToString(m_impl->metadata.main_dol));
     s_boot_session_data.reset();
   }
   if (!boot) {

--- a/tests/launcher_savestates_test.cpp
+++ b/tests/launcher_savestates_test.cpp
@@ -1,0 +1,110 @@
+#include "launcher_savestates.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+void Touch(const fs::path& path, char contents, std::chrono::hours age)
+{
+  std::ofstream(path).put(contents);
+  std::error_code ec;
+  fs::last_write_time(path, fs::file_time_type::clock::now() - age, ec);
+}
+}  // namespace
+
+int main()
+{
+  const fs::path root = fs::temp_directory_path() / "moderngekko-launcher-savestate-test";
+  std::error_code ec;
+  fs::remove_all(root, ec);
+  fs::create_directories(root, ec);
+  if (ec)
+    return 1;
+
+  const fs::path old_state = root / "player-old.sav";
+  const fs::path latest_state = root / "player-latest.sav";
+  const fs::path ignored_file = root / "notes.txt";
+  Touch(old_state, 'a', std::chrono::hours(1));
+  Touch(latest_state, 'b', std::chrono::hours(0));
+  std::ofstream(ignored_file).put('c');
+
+  // Newest first, and anything that is not a .sav stays out of the list.
+  const auto states = moderngekko::frontend::ListLauncherSavestates(root);
+  if (states.size() != 2 || states[0].filename() != latest_state.filename() ||
+      states[1].filename() != old_state.filename())
+  {
+    fs::remove_all(root, ec);
+    return 2;
+  }
+  if (moderngekko::frontend::LauncherSavestateLabel(states[0], true) !=
+          "Latest - player-latest.sav" ||
+      moderngekko::frontend::LauncherSavestateLabel(states[1], false) != "player-old.sav")
+  {
+    fs::remove_all(root, ec);
+    return 3;
+  }
+
+  const fs::path recovery_old = root / "recovery-001-old.sav";
+  const fs::path recovery_latest = root / "recovery-002-latest.sav";
+  Touch(recovery_old, 'd', std::chrono::hours(2));
+  Touch(recovery_latest, 'e', std::chrono::hours(0));
+
+  const auto newest_recovery = moderngekko::frontend::LatestRecoverySavestate(root);
+  if (!newest_recovery || newest_recovery->filename() != recovery_latest.filename())
+  {
+    fs::remove_all(root, ec);
+    return 4;
+  }
+
+  // Pruning takes automatic states only. A player's own savestates must survive
+  // regardless of how many automatic ones accumulate.
+  if (moderngekko::frontend::PruneRecoverySavestates(root, 1) != 1 ||
+      fs::exists(recovery_old) || !fs::exists(recovery_latest) ||
+      !fs::exists(old_state) || !fs::exists(latest_state))
+  {
+    fs::remove_all(root, ec);
+    return 5;
+  }
+
+  // A game may name its automatic states after whatever triggers them. Under a
+  // different prefix the default-prefixed files are somebody else's business
+  // and must not be listed or pruned.
+  const fs::path chapter_old = root / "chapter-001.sav";
+  const fs::path chapter_new = root / "chapter-002.sav";
+  Touch(chapter_old, 'f', std::chrono::hours(3));
+  Touch(chapter_new, 'g', std::chrono::hours(0));
+  const auto chapters = moderngekko::frontend::ListRecoverySavestates(root, "chapter-");
+  if (chapters.size() != 2 || chapters[0].filename() != chapter_new.filename())
+  {
+    fs::remove_all(root, ec);
+    return 6;
+  }
+  if (moderngekko::frontend::PruneRecoverySavestates(root, 1, "chapter-") != 1 ||
+      fs::exists(chapter_old) || !fs::exists(chapter_new) ||
+      !fs::exists(recovery_latest) || !fs::exists(latest_state))
+  {
+    fs::remove_all(root, ec);
+    return 7;
+  }
+
+  // Keeping more than exist is not an error and removes nothing.
+  if (moderngekko::frontend::PruneRecoverySavestates(root, 10) != 0)
+  {
+    fs::remove_all(root, ec);
+    return 8;
+  }
+
+  // A directory that is not there yields an empty list rather than throwing.
+  if (!moderngekko::frontend::ListLauncherSavestates(root / "absent").empty())
+  {
+    fs::remove_all(root, ec);
+    return 9;
+  }
+
+  fs::remove_all(root, ec);
+  return 0;
+}

--- a/tests/launcher_savestates_test.cpp
+++ b/tests/launcher_savestates_test.cpp
@@ -1,113 +1,52 @@
+// The listing, ordering and pruning rules are defined and tested in the runtime
+// (Core/SavestateLayout.h, SavestateLayoutTest). What is left here is the
+// launcher's own concern -- how an entry is labelled -- plus one check that the
+// delegation is wired up, so this cannot silently stop calling the shared
+// definition and start drifting from the in-game menu.
 #include "launcher_savestates.hpp"
 
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <string>
 
 namespace fs = std::filesystem;
 
-namespace
-{
-void Touch(const fs::path& path, char contents, std::chrono::hours age)
-{
-  std::ofstream(path).put(contents);
-  std::error_code ec;
-  fs::last_write_time(path, fs::file_time_type::clock::now() - age, ec);
-}
-}  // namespace
-
 int main()
 {
-  // Timestamped, as the other tests here are: a fixed name collides when two
-  // runs overlap, and inherits whatever a previously crashed run left behind.
+  // Unique per run: a fixed name races when two runs overlap and inherits
+  // whatever a run that died before cleanup left behind.
   const fs::path root =
       fs::temp_directory_path() /
       ("moderngekko-launcher-savestates-" +
        std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
   std::error_code ec;
-  fs::remove_all(root, ec);
   fs::create_directories(root, ec);
   if (ec)
     return 1;
 
-  const fs::path old_state = root / "player-old.sav";
-  const fs::path latest_state = root / "player-latest.sav";
-  const fs::path ignored_file = root / "notes.txt";
-  Touch(old_state, 'a', std::chrono::hours(1));
-  Touch(latest_state, 'b', std::chrono::hours(0));
-  std::ofstream(ignored_file).put('c');
+  const fs::path older = root / "player-old.sav";
+  const fs::path newer = root / "player-latest.sav";
+  std::ofstream(older).put('a');
+  std::ofstream(newer).put('b');
+  fs::last_write_time(older, fs::file_time_type::clock::now() - std::chrono::hours(1), ec);
+  fs::last_write_time(newer, fs::file_time_type::clock::now(), ec);
 
-  // Newest first, and anything that is not a .sav stays out of the list.
+  // Delegation: newest first, straight from the shared definition.
   const auto states = moderngekko::frontend::ListLauncherSavestates(root);
-  if (states.size() != 2 || states[0].filename() != latest_state.filename() ||
-      states[1].filename() != old_state.filename())
+  if (states.size() != 2 || states[0].filename() != newer.filename() ||
+      states[1].filename() != older.filename())
   {
     fs::remove_all(root, ec);
     return 2;
   }
+
   if (moderngekko::frontend::LauncherSavestateLabel(states[0], true) !=
           "Latest - player-latest.sav" ||
       moderngekko::frontend::LauncherSavestateLabel(states[1], false) != "player-old.sav")
   {
     fs::remove_all(root, ec);
     return 3;
-  }
-
-  const fs::path recovery_old = root / "recovery-001-old.sav";
-  const fs::path recovery_latest = root / "recovery-002-latest.sav";
-  Touch(recovery_old, 'd', std::chrono::hours(2));
-  Touch(recovery_latest, 'e', std::chrono::hours(0));
-
-  const auto newest_recovery = moderngekko::frontend::LatestRecoverySavestate(root);
-  if (!newest_recovery || newest_recovery->filename() != recovery_latest.filename())
-  {
-    fs::remove_all(root, ec);
-    return 4;
-  }
-
-  // Pruning takes automatic states only. A player's own savestates must survive
-  // regardless of how many automatic ones accumulate.
-  if (moderngekko::frontend::PruneRecoverySavestates(root, 1) != 1 ||
-      fs::exists(recovery_old) || !fs::exists(recovery_latest) ||
-      !fs::exists(old_state) || !fs::exists(latest_state))
-  {
-    fs::remove_all(root, ec);
-    return 5;
-  }
-
-  // A game may name its automatic states after whatever triggers them. Under a
-  // different prefix the default-prefixed files are somebody else's business
-  // and must not be listed or pruned.
-  const fs::path chapter_old = root / "chapter-001.sav";
-  const fs::path chapter_new = root / "chapter-002.sav";
-  Touch(chapter_old, 'f', std::chrono::hours(3));
-  Touch(chapter_new, 'g', std::chrono::hours(0));
-  const auto chapters = moderngekko::frontend::ListRecoverySavestates(root, "chapter-");
-  if (chapters.size() != 2 || chapters[0].filename() != chapter_new.filename())
-  {
-    fs::remove_all(root, ec);
-    return 6;
-  }
-  if (moderngekko::frontend::PruneRecoverySavestates(root, 1, "chapter-") != 1 ||
-      fs::exists(chapter_old) || !fs::exists(chapter_new) ||
-      !fs::exists(recovery_latest) || !fs::exists(latest_state))
-  {
-    fs::remove_all(root, ec);
-    return 7;
-  }
-
-  // Keeping more than exist is not an error and removes nothing.
-  if (moderngekko::frontend::PruneRecoverySavestates(root, 10) != 0)
-  {
-    fs::remove_all(root, ec);
-    return 8;
-  }
-
-  // A directory that is not there yields an empty list rather than throwing.
-  if (!moderngekko::frontend::ListLauncherSavestates(root / "absent").empty())
-  {
-    fs::remove_all(root, ec);
-    return 9;
   }
 
   fs::remove_all(root, ec);

--- a/tests/launcher_savestates_test.cpp
+++ b/tests/launcher_savestates_test.cpp
@@ -49,6 +49,14 @@ int main()
     return 3;
   }
 
+  const fs::path unicode_name = fs::path(std::u8string(u8"state-プレイヤー.sav"));
+  if (moderngekko::frontend::LauncherSavestateLabel(unicode_name, false) !=
+      "state-プレイヤー.sav")
+  {
+    fs::remove_all(root, ec);
+    return 4;
+  }
+
   fs::remove_all(root, ec);
   return 0;
 }

--- a/tests/launcher_savestates_test.cpp
+++ b/tests/launcher_savestates_test.cpp
@@ -18,7 +18,12 @@ void Touch(const fs::path& path, char contents, std::chrono::hours age)
 
 int main()
 {
-  const fs::path root = fs::temp_directory_path() / "moderngekko-launcher-savestate-test";
+  // Timestamped, as the other tests here are: a fixed name collides when two
+  // runs overlap, and inherits whatever a previously crashed run left behind.
+  const fs::path root =
+      fs::temp_directory_path() /
+      ("moderngekko-launcher-savestates-" +
+       std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
   std::error_code ec;
   fs::remove_all(root, ec);
   fs::create_directories(root, ec);

--- a/tools/launcher_savestates.hpp
+++ b/tools/launcher_savestates.hpp
@@ -1,94 +1,34 @@
 #pragma once
 
-#include <algorithm>
+// Presentation only. Where savestates live, what they are called, and what order
+// they list in is defined once in the runtime and included here rather than
+// restated -- see Core/SavestateLayout.h. Two copies of that rule would let the
+// launcher and the in-game menu show the same directory in a different order,
+// which is a confusing bug and an easy one to introduce by editing one side.
+
+#include "Core/SavestateLayout.h"
+
 #include <filesystem>
-#include <optional>
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace moderngekko::frontend
 {
 namespace fs = std::filesystem;
 
-// Automatic savestates are distinguished from ones the player took by a
-// filename prefix rather than by a separate directory, so that both kinds list
-// together in the launcher in one pass. A game that wants to name its automatic
-// states after whatever it triggers them on -- room transitions, checkpoints,
-// chapter breaks -- keeps this prefix and appends its own suffix.
-inline constexpr std::string_view DEFAULT_RECOVERY_PREFIX = "recovery-";
+using State::Layout::LatestAutomatic;
+using State::Layout::ListAutomatic;
+using State::Layout::PruneAutomatic;
 
 inline std::vector<fs::path> ListLauncherSavestates(const fs::path& directory)
 {
-  std::vector<fs::path> paths;
-  std::error_code ec;
-  if (!fs::is_directory(directory, ec))
-    return paths;
-
-  for (const fs::directory_entry& entry : fs::directory_iterator(directory, ec))
-  {
-    if (entry.is_regular_file(ec) && entry.path().extension() == ".sav")
-      paths.push_back(entry.path());
-  }
-
-  // Newest first, because the state a player wants next is nearly always the
-  // one they just took. Filename is the tiebreak so the order is stable when
-  // two states share a timestamp, and so a filesystem with coarse timestamp
-  // granularity does not produce a different list on each launch.
-  std::ranges::sort(paths, [](const fs::path& left, const fs::path& right) {
-    std::error_code left_ec;
-    std::error_code right_ec;
-    const auto left_time = fs::last_write_time(left, left_ec);
-    const auto right_time = fs::last_write_time(right, right_ec);
-    if (!left_ec && !right_ec && left_time != right_time)
-      return left_time > right_time;
-    return left.filename().string() < right.filename().string();
-  });
-  return paths;
+  return State::Layout::List(directory);
 }
 
+// The newest entry is worth calling out: it is preselected because it is the one
+// a player almost always wants next, so the label says why it is at the top.
 inline std::string LauncherSavestateLabel(const fs::path& path, bool latest)
 {
   return latest ? "Latest - " + path.filename().string() : path.filename().string();
-}
-
-inline std::vector<fs::path>
-ListRecoverySavestates(const fs::path& directory,
-                       std::string_view prefix = DEFAULT_RECOVERY_PREFIX)
-{
-  std::vector<fs::path> paths;
-  for (const fs::path& path : ListLauncherSavestates(directory))
-  {
-    if (path.filename().string().starts_with(prefix))
-      paths.push_back(path);
-  }
-  return paths;
-}
-
-inline std::optional<fs::path>
-LatestRecoverySavestate(const fs::path& directory,
-                        std::string_view prefix = DEFAULT_RECOVERY_PREFIX)
-{
-  const std::vector<fs::path> paths = ListRecoverySavestates(directory, prefix);
-  return paths.empty() ? std::nullopt : std::optional<fs::path>(paths.front());
-}
-
-// Deletes all but the newest `keep` automatic states, and returns how many went.
-// Only files carrying the prefix are considered, so a player's own savestates
-// are never pruned no matter how many accumulate.
-inline std::size_t
-PruneRecoverySavestates(const fs::path& directory, std::size_t keep,
-                        std::string_view prefix = DEFAULT_RECOVERY_PREFIX)
-{
-  const std::vector<fs::path> recovery_states = ListRecoverySavestates(directory, prefix);
-  std::error_code ec;
-  std::size_t removed = 0;
-  for (std::size_t index = keep; index < recovery_states.size(); ++index)
-  {
-    ec.clear();
-    if (fs::remove(recovery_states[index], ec))
-      ++removed;
-  }
-  return removed;
 }
 }  // namespace moderngekko::frontend

--- a/tools/launcher_savestates.hpp
+++ b/tools/launcher_savestates.hpp
@@ -25,10 +25,16 @@ inline std::vector<fs::path> ListLauncherSavestates(const fs::path& directory)
   return State::Layout::List(directory);
 }
 
-// The newest entry is worth calling out: it is preselected because it is the one
-// a player almost always wants next, so the label says why it is at the top.
+inline std::string PathText(const fs::path& path)
+{
+  const std::u8string encoded = path.u8string();
+  return {encoded.begin(), encoded.end()};
+}
+
+// The newest entry is worth calling out so the label explains why it is first.
 inline std::string LauncherSavestateLabel(const fs::path& path, bool latest)
 {
-  return latest ? "Latest - " + path.filename().string() : path.filename().string();
+  const std::string filename = PathText(path.filename());
+  return latest ? "Latest - " + filename : filename;
 }
 }  // namespace moderngekko::frontend

--- a/tools/launcher_savestates.hpp
+++ b/tools/launcher_savestates.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <algorithm>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace moderngekko::frontend
+{
+namespace fs = std::filesystem;
+
+// Automatic savestates are distinguished from ones the player took by a
+// filename prefix rather than by a separate directory, so that both kinds list
+// together in the launcher in one pass. A game that wants to name its automatic
+// states after whatever it triggers them on -- room transitions, checkpoints,
+// chapter breaks -- keeps this prefix and appends its own suffix.
+inline constexpr std::string_view DEFAULT_RECOVERY_PREFIX = "recovery-";
+
+inline std::vector<fs::path> ListLauncherSavestates(const fs::path& directory)
+{
+  std::vector<fs::path> paths;
+  std::error_code ec;
+  if (!fs::is_directory(directory, ec))
+    return paths;
+
+  for (const fs::directory_entry& entry : fs::directory_iterator(directory, ec))
+  {
+    if (entry.is_regular_file(ec) && entry.path().extension() == ".sav")
+      paths.push_back(entry.path());
+  }
+
+  // Newest first, because the state a player wants next is nearly always the
+  // one they just took. Filename is the tiebreak so the order is stable when
+  // two states share a timestamp, and so a filesystem with coarse timestamp
+  // granularity does not produce a different list on each launch.
+  std::ranges::sort(paths, [](const fs::path& left, const fs::path& right) {
+    std::error_code left_ec;
+    std::error_code right_ec;
+    const auto left_time = fs::last_write_time(left, left_ec);
+    const auto right_time = fs::last_write_time(right, right_ec);
+    if (!left_ec && !right_ec && left_time != right_time)
+      return left_time > right_time;
+    return left.filename().string() < right.filename().string();
+  });
+  return paths;
+}
+
+inline std::string LauncherSavestateLabel(const fs::path& path, bool latest)
+{
+  return latest ? "Latest - " + path.filename().string() : path.filename().string();
+}
+
+inline std::vector<fs::path>
+ListRecoverySavestates(const fs::path& directory,
+                       std::string_view prefix = DEFAULT_RECOVERY_PREFIX)
+{
+  std::vector<fs::path> paths;
+  for (const fs::path& path : ListLauncherSavestates(directory))
+  {
+    if (path.filename().string().starts_with(prefix))
+      paths.push_back(path);
+  }
+  return paths;
+}
+
+inline std::optional<fs::path>
+LatestRecoverySavestate(const fs::path& directory,
+                        std::string_view prefix = DEFAULT_RECOVERY_PREFIX)
+{
+  const std::vector<fs::path> paths = ListRecoverySavestates(directory, prefix);
+  return paths.empty() ? std::nullopt : std::optional<fs::path>(paths.front());
+}
+
+// Deletes all but the newest `keep` automatic states, and returns how many went.
+// Only files carrying the prefix are considered, so a player's own savestates
+// are never pruned no matter how many accumulate.
+inline std::size_t
+PruneRecoverySavestates(const fs::path& directory, std::size_t keep,
+                        std::string_view prefix = DEFAULT_RECOVERY_PREFIX)
+{
+  const std::vector<fs::path> recovery_states = ListRecoverySavestates(directory, prefix);
+  std::error_code ec;
+  std::size_t removed = 0;
+  for (std::size_t index = keep; index < recovery_states.size(); ++index)
+  {
+    ec.clear();
+    if (fs::remove(recovery_states[index], ec))
+      ++removed;
+  }
+  return removed;
+}
+}  // namespace moderngekko::frontend

--- a/tools/moderngekko_launcher.cpp
+++ b/tools/moderngekko_launcher.cpp
@@ -1,5 +1,6 @@
 #include "frontend_config.hpp"
 #include "dol_patch.hpp"
+#include "launcher_savestates.hpp"
 #include "moderngekko/game.hpp"
 #include "netplay_session.hpp"
 
@@ -617,6 +618,16 @@ int main(int argc, char** argv)
       graphics_backend_index = static_cast<int>(i);
   }
 
+  // Listed once at startup rather than every frame, so the dropdown does not
+  // hit the filesystem on each redraw. A state written while the launcher is
+  // open therefore appears on the next launch, which is the case that matters:
+  // states are written by the running game, not by the launcher.
+  const std::vector<fs::path> launcher_savestates =
+      moderngekko::frontend::ListLauncherSavestates(user_directory / "states");
+  // Newest first, so index 0 is the most recent. Default to it when one exists:
+  // resuming is the common case, and "Normal boot" stays one click away.
+  int selected_savestate = launcher_savestates.empty() ? -1 : 0;
+
   DialogState dialog;
   std::vector<ControllerOption> controllers = EnumerateControllers();
   bool controller_profile_exists = moderngekko::frontend::ControllerConfigExists(user_directory);
@@ -772,6 +783,40 @@ int main(int argc, char** argv)
     {
       ImGui::Text("Ready: %s [%s]", current_metadata.metadata->game_name.c_str(),
                   current_metadata.metadata->disc_id.c_str());
+      if (!launcher_savestates.empty())
+      {
+        ImGui::TextUnformatted("Start from savestate");
+        const std::string savestate_preview =
+            selected_savestate >= 0 ?
+                moderngekko::frontend::LauncherSavestateLabel(
+                    launcher_savestates[static_cast<std::size_t>(selected_savestate)],
+                    selected_savestate == 0) :
+                "Normal boot";
+        if (ImGui::BeginCombo("##launch_savestate", savestate_preview.c_str()))
+        {
+          const bool normal_boot_selected = selected_savestate < 0;
+          if (ImGui::Selectable("Normal boot", normal_boot_selected))
+            selected_savestate = -1;
+          if (normal_boot_selected)
+            ImGui::SetItemDefaultFocus();
+
+          for (std::size_t i = 0; i < launcher_savestates.size(); ++i)
+          {
+            const std::string label =
+                moderngekko::frontend::LauncherSavestateLabel(launcher_savestates[i], i == 0);
+            const bool selected = selected_savestate == static_cast<int>(i);
+            if (ImGui::Selectable(label.c_str(), selected))
+              selected_savestate = static_cast<int>(i);
+            if (selected)
+              ImGui::SetItemDefaultFocus();
+          }
+          ImGui::EndCombo();
+        }
+        // Netplay starts every player from the same boot, so a state chosen by
+        // one side would desync the session immediately.
+        ImGui::TextDisabled("Solo play only.");
+        ImGui::Spacing();
+      }
       if (ImGui::Button("Play", ImVec2(180 * scale, 42 * scale)))
       {
         if (ensure_controller())
@@ -1070,6 +1115,14 @@ int main(int argc, char** argv)
       std::vector<std::string> argument_storage = {SiblingRunner(argv[0]).string(), "--game",
                                                    current_game.string(), "--user-dir",
                                                    user_directory.string()};
+      // Solo only: see the note by the dropdown.
+      if (launch_mode == LaunchMode::Solo && selected_savestate >= 0 &&
+          static_cast<std::size_t>(selected_savestate) < launcher_savestates.size())
+      {
+        argument_storage.emplace_back("--load-state");
+        argument_storage.emplace_back(
+            launcher_savestates[static_cast<std::size_t>(selected_savestate)].string());
+      }
       if (launch_mode == LaunchMode::Host)
         argument_storage.emplace_back("--netplay-host");
       else if (launch_mode == LaunchMode::Join)

--- a/tools/moderngekko_launcher.cpp
+++ b/tools/moderngekko_launcher.cpp
@@ -618,12 +618,15 @@ int main(int argc, char** argv)
       graphics_backend_index = static_cast<int>(i);
   }
 
+  // StateSaves is Dolphin's own state directory, so states written in-game land
+  // here without any extra configuration and show up on the next launch.
+  //
   // Listed once at startup rather than every frame, so the dropdown does not
   // hit the filesystem on each redraw. A state written while the launcher is
   // open therefore appears on the next launch, which is the case that matters:
   // states are written by the running game, not by the launcher.
   const std::vector<fs::path> launcher_savestates =
-      moderngekko::frontend::ListLauncherSavestates(user_directory / "states");
+      moderngekko::frontend::ListLauncherSavestates(user_directory / "StateSaves");
   // Newest first, so index 0 is the most recent. Default to it when one exists:
   // resuming is the common case, and "Normal boot" stays one click away.
   int selected_savestate = launcher_savestates.empty() ? -1 : 0;

--- a/tools/moderngekko_launcher.cpp
+++ b/tools/moderngekko_launcher.cpp
@@ -627,9 +627,9 @@ int main(int argc, char** argv)
   // states are written by the running game, not by the launcher.
   const std::vector<fs::path> launcher_savestates =
       moderngekko::frontend::ListLauncherSavestates(user_directory / "StateSaves");
-  // Newest first, so index 0 is the most recent. Default to it when one exists:
-  // resuming is the common case, and "Normal boot" stays one click away.
-  int selected_savestate = launcher_savestates.empty() ? -1 : 0;
+  // Loading is always explicit. StateSaves is shared by games, so selecting the
+  // newest file automatically could try to resume a different title.
+  int selected_savestate = -1;
 
   DialogState dialog;
   std::vector<ControllerOption> controllers = EnumerateControllers();
@@ -1124,7 +1124,8 @@ int main(int argc, char** argv)
       {
         argument_storage.emplace_back("--load-state");
         argument_storage.emplace_back(
-            launcher_savestates[static_cast<std::size_t>(selected_savestate)].string());
+            moderngekko::frontend::PathText(
+                launcher_savestates[static_cast<std::size_t>(selected_savestate)]));
       }
       if (launch_mode == LaunchMode::Host)
         argument_storage.emplace_back("--netplay-host");

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -32,7 +32,7 @@ void HandleStopSignal(int) { s_stop_requested = 1; }
 void Usage() {
   std::cerr << "usage: " MODERNGEKKO_RUNNER_NAME
                " [--game <extracted-root>] [--module <path>]\n"
-               "       [--user-dir <path>] [--title <text>]\n"
+               "       [--user-dir <path>] [--title <text>] [--load-state <path>]\n"
                "       [--graphics <backend>] [--audio <backend>]\n"
                "       [--mods <directory>] [--no-mods]\n"
                "       [--wayland] [-X11] [--headless] [--allow-interpreter]\n"
@@ -153,6 +153,18 @@ int RunMain(int argc, char **argv) {
       config.user_directory = value("--user-dir");
     else if (arg == "--title")
       config.window_title = value("--title");
+    else if (arg == "--load-state")
+    {
+      // Checked here rather than left to the boot path: a state that is not
+      // there would otherwise boot to the title screen and look like it worked.
+      std::filesystem::path state = value("--load-state");
+      if (!std::filesystem::exists(state))
+      {
+        std::cerr << "savestate not found: " << state.string() << '\n';
+        return 2;
+      }
+      config.load_state_path = std::move(state);
+    }
     else if (arg == "--graphics")
       config.graphics.backend = value("--graphics");
     else if (arg == "--audio")

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -4,6 +4,8 @@
 #include "moderngekko/runtime.hpp"
 #include "netplay_session.hpp"
 
+#include "Common/StringUtil.h"
+
 #include <charconv>
 #include <chrono>
 #include <csignal>
@@ -157,10 +159,10 @@ int RunMain(int argc, char **argv) {
     {
       // Checked here rather than left to the boot path: a state that is not
       // there would otherwise boot to the title screen and look like it worked.
-      std::filesystem::path state = value("--load-state");
-      if (!std::filesystem::exists(state))
+      std::filesystem::path state = StringToPath(value("--load-state"));
+      if (!std::filesystem::is_regular_file(state))
       {
-        std::cerr << "savestate not found: " << state.string() << '\n';
+        std::cerr << "savestate not found: " << PathToString(state) << '\n';
         return 2;
       }
       config.load_state_path = std::move(state);


### PR DESCRIPTION
Booting to the title screen and playing in is currently the only way back to a scene. That makes any repeated task â€” testing a fix, checking a level, benchmarking â€” cost several minutes of the same input every time.

This adds savestate loading to the runtime and a picker to the launcher: `.sav` files are listed from `<user>/StateSaves`, newest first, and the chosen one is passed to the runner as `--load-state`. The dropdown only appears when that directory has states in it, so nothing changes for anyone who never writes one.

![savestate picker, open](https://raw.githubusercontent.com/dougchansan/ModernGekko/pr-assets/assets/savestate-picker-open.png)

The four states were written with staggered timestamps and the list orders them accordingly, with `Normal boot` pinned first.

![the launcher with the picker collapsed](https://raw.githubusercontent.com/dougchansan/ModernGekko/pr-assets/assets/savestate-picker-launcher.png)

### Two commits

**Load a savestate at boot.** `RuntimeConfig::load_state_path`, boot through `BootSessionData` when it is set, and `--load-state` on the runner. The path is checked before boot rather than left to Dolphin, which reports a rejected state only on the OSD â€” a missing file would otherwise boot to the title screen and look like it had worked.

**The launcher picker.** Lists states, passes the choice through.

`StateSaves` is Dolphin's own state directory, so a state written in-game is offered by the launcher next time with no extra configuration.

### Design notes

**Newest-first, with a filename tiebreak** rather than sorting by name. The state a player wants next is nearly always the one they just took. The tiebreak keeps the order stable when two states share a write time, which happens on filesystems with coarse timestamp granularity â€” without it the list could come back in a different order on each launch.

**Automatic states are distinguished by a filename prefix, not a separate directory**, so both kinds list together in one pass. The prefix defaults to `recovery-` and is a parameter, so a game can name its automatic states after whatever triggers them. Pruning only ever considers prefixed files, so a player's own savestates are never removed no matter how many automatic ones accumulate. There is a test for exactly that.

**Listed once at startup**, not per frame, so the dropdown does not hit the filesystem on every redraw. States are written by the running game rather than by the launcher, so one written while the launcher is open appearing on the next launch is correct, not a staleness bug.

**Solo only.** Netplay starts every player from the same boot, so a state chosen by one side would desync the session immediately.

### Testing

`tests/launcher_savestates_test.cpp` covers ordering, non-`.sav` files being ignored, label formatting, prefix filtering under the default and a custom prefix, pruning leaving player states alone, keeping more than exist, and a missing directory returning empty rather than throwing. It is header-only, so it needs no companion translation unit. I checked it is load-bearing by mutating what it guards â€” making prune ignore the prefix fails it (exit 5), reversing the sort fails it (exit 2).

End to end on a real build (MSVC/Ninja Release): the launcher lists the states, `Play` boots straight into the chosen one, and the game runs at ~30 FPS in the scene rather than at the title screen. The screenshots are that build.

`ctest` â€” 38 of 41 pass. The three failures (`dol_patch`, `frontend_config`, `frontend_config_gamecube`, all `0xC0000409`) and one build failure (`netplay_protocol_test`, `__VA_OPT__ ... requires '/Zc:preprocessor'`) are pre-existing on MSVC and unrelated: those targets compile only their own sources, none of which this PR touches.

### Prerequisite

`moderngekko-launcher` does not build from `master`. The pinned RecompCore applies PCH flags unconditionally, so C sources get a C++ precompiled header (`cpu_exception.c: fatal error C1853`); **#18 fixes that**. After it, `core` still needs ExpansionPak/RecompCore#7. I built with both applied.

### How this fits

These land together as a set: savestates working end to end, the Windows build
and test suite being usable at all, and CI so none of it regresses unnoticed.
**This PR is MG #21.**

| | | |
|---|---|---|
| MG #18 | Bump vendored RecompCore | **prerequisite** - without it the launcher cannot compile on Windows (C sources get a C++ PCH) |
| RC #7 | `Interpreter.cpp` include | **prerequisite** - `core` does not compile without it |
| RC #8 | In-game File/View menu and hotkeys | introduces `Core/SavestateLayout.h`, the one definition of where savestates live, what they are called and how they are ordered |
| MG #21 | Launcher savestate picker, `--load-state` | consumes that header, so the launcher and the in-game menu cannot disagree |
| MG #22 | Make the test suite pass on Windows | **land before CI**, or the first run is red on day one |
| MG #23 | Build and test on PRs, three platforms | the reason the rest stayed broken unnoticed |
| RC #10 | CI on PRs, the vendored branch, and Windows | same gap, other repo; its Windows job fails until RC #7 lands |
| MG #19 | `--opt-level`, default `-O2` | independent |
| MG #20 | Cache-domain affinity | independent |

Suggested order: **#18 and RC #7**, then RC #8, then MG #21; **MG #22 before MG
#23**. The rest are independent.

Verified on three platforms: Windows (MSVC + clang), Linux (g++ 15.2, x86_64) and
macOS 26.1 (clang, arm64). The portable pieces - the savestate layout and its
tests, `frontend_config`, `dol_patch` - build and pass on all three. Windows-only
pieces are guarded and their tests registered behind `if(WIN32)`.
