### PR TITLE
Make the test suite pass on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -692,6 +692,21 @@ if(BUILD_TESTING)
             target_link_libraries(moderngekko_netplay_protocol_test PRIVATE
                 ModernGekko::Runtime core uicommon)
         endif()
+        if(WIN32)
+            # The same treatment the non-test Windows targets get from the loop
+            # above, which runs before the test targets exist and so misses
+            # them. WIN32_LEAN_AND_MEAN keeps windows.h from pulling in
+            # winsock.h, which would clash with the winsock2.h this reaches
+            # through Dolphin's networking headers ('sockaddr' redefinition).
+            target_compile_definitions(moderngekko_netplay_protocol_test PRIVATE
+                WIN32_LEAN_AND_MEAN NOMINMAX)
+            if(MSVC)
+                # Dolphin's headers use __VA_OPT__, which the traditional
+                # preprocessor cannot parse.
+                target_compile_options(moderngekko_netplay_protocol_test PRIVATE
+                    /Zc:preprocessor)
+            endif()
+        endif()
         add_test(NAME moderngekko.netplay_protocol COMMAND moderngekko_netplay_protocol_test)
     endif()
 

--- a/tests/dol_patch_test.cpp
+++ b/tests/dol_patch_test.cpp
@@ -61,8 +61,12 @@ int main() {
     std::cerr << error << '\n';
     return 1;
   }
-  std::ifstream input(dol, std::ios::binary);
-  input.read(reinterpret_cast<char *>(bytes.data()), bytes.size());
+  // Scoped: Windows will not delete a file that is still open, so an ifstream
+  // left open here makes the remove_all below throw on that platform only.
+  {
+    std::ifstream input(dol, std::ios::binary);
+    input.read(reinterpret_cast<char *>(bytes.data()), bytes.size());
+  }
   if (ReadBE32(bytes.data() + 0x100) != 0x4800000C ||
       ReadBE32(bytes.data() + 0x104) != 0x7C000050)
     return 1;

--- a/tests/frontend_config_test.cpp
+++ b/tests/frontend_config_test.cpp
@@ -78,9 +78,15 @@ int main() {
       netplay_config.controllers)
     return 10;
 
-  std::ifstream input(directory / "Config" / CONTROLLER_CONFIG_NAME);
-  const std::string generated{std::istreambuf_iterator<char>(input),
-                              std::istreambuf_iterator<char>()};
+  // Scoped so the handle is closed before the cleanup below. Windows refuses
+  // to delete a file that is still open, where POSIX allows it, so leaving
+  // these open makes remove_all throw there and only there.
+  std::string generated;
+  {
+    std::ifstream input(directory / "Config" / CONTROLLER_CONFIG_NAME);
+    generated.assign(std::istreambuf_iterator<char>(input),
+                     std::istreambuf_iterator<char>());
+  }
 #ifdef MODERNGEKKO_GAMECUBE_CONTROLLERS
   if (!generated.contains("Buttons/A = `Button A`\n") ||
       !generated.contains("Buttons/Z = `Shoulder R`\n") ||
@@ -122,9 +128,12 @@ int main() {
   if (!moderngekko::frontend::EnsureControllerConfig(
           directory, netplay_config.controllers, &error))
     return 11;
-  std::ifstream custom_input(directory / "Config" / CONTROLLER_CONFIG_NAME);
-  const std::string preserved{std::istreambuf_iterator<char>(custom_input),
-                              std::istreambuf_iterator<char>()};
+  std::string preserved;
+  {
+    std::ifstream custom_input(directory / "Config" / CONTROLLER_CONFIG_NAME);
+    preserved.assign(std::istreambuf_iterator<char>(custom_input),
+                     std::istreambuf_iterator<char>());
+  }
   if (preserved != custom || moderngekko::frontend::ReadConfiguredController(
                                  directory) != "SDL/9/Custom Controller")
     return 12;


### PR DESCRIPTION
Three tests fail on Windows and a fourth does not build. None of it shows on Linux or macOS, and the repo has no CI, so it has gone unnoticed.

```
The following tests FAILED:
   1 - moderngekko.dol_patch (Exit code 0xc0000409)
   2 - moderngekko.frontend_config (Exit code 0xc0000409)
   4 - moderngekko.frontend_config_gamecube (Exit code 0xc0000409)
   5 - moderngekko.netplay_protocol (Not Run)
```

### The two crashes are the same bug

`frontend_config_test` and `dol_patch_test` both hold a `std::ifstream` open on a file *inside* the directory they then pass to `fs::remove_all`. POSIX lets you unlink an open file; Windows does not. So `remove_all` throws `filesystem_error`, nothing catches it, and the process dies in `terminate()`.

The exit code is a red herring worth naming: MSVC's `abort()` raises `__fastfail`, which surfaces as **`0xC0000409` â€” `STATUS_STACK_BUFFER_OVERRUN`**. That reads as memory corruption and sends you hunting for an overflow that does not exist. Instrumenting the test showed every assertion passing and the crash landing squarely on cleanup:

```
O2: preserved=63 custom=63 equal=1
P: cleanup (custom_input still open)
P-THREW: remove_all: The process cannot access the file because it is
         being used by another process.
```

Scoping the streams so they close before cleanup is the entire fix. (`launcher_savestates_test` already passes on Windows because it uses the `error_code` overload, which reports rather than throws.)

### The build failure is two missing flags

`netplay_protocol_test` reaches Dolphin headers that use `__VA_OPT__`, which the traditional preprocessor cannot parse:

```
Common/Crypto/SHA1.h(44): error C2760: syntax error: '__VA_OPT__' was unexpected here
```

and with that fixed, `windows.h` pulls in `winsock.h`, which collides with the `winsock2.h` it also reaches:

```
ws2def.h(246): error C2011: 'sockaddr': 'struct' type redefinition
```

The non-test Windows targets already get `/Zc:preprocessor` and `WIN32_LEAN_AND_MEAN NOMINMAX` â€” from a `foreach` loop that runs *before* the test targets are defined, so `if(TARGET ...)` is false for all of them and they are silently skipped. Applying the same treatment at the target itself is the fix.

### Result

MSVC / Ninja / Release, Windows 11:

| | before | after |
|---|---|---|
| `moderngekko.*` tests | 22 pass, 3 fail, 1 unbuilt | **26 / 26 pass** |
| whole suite (built targets) | â€” | **all pass** |

The only remaining entries are `fullbench`, `fuzzer` and `zstreamtest`, which are vendored **zstd**'s own tests: registered by its CMake but never built here, so they report "Not Run". Unrelated to this repo and left alone.

No production code changes â€” two test files and one CMake block.

### How this fits

These land together as a set: savestates working end to end, the Windows build
and test suite being usable at all, and CI so none of it regresses unnoticed.
**This PR is MG #22.**

| | | |
|---|---|---|
| MG #18 | Bump vendored RecompCore | **prerequisite** - without it the launcher cannot compile on Windows (C sources get a C++ PCH) |
| RC #7 | `Interpreter.cpp` include | **prerequisite** - `core` does not compile without it |
| RC #8 | In-game File/View menu and hotkeys | introduces `Core/SavestateLayout.h`, the one definition of where savestates live, what they are called and how they are ordered |
| MG #21 | Launcher savestate picker, `--load-state` | consumes that header, so the launcher and the in-game menu cannot disagree |
| MG #22 | Make the test suite pass on Windows | **land before CI**, or the first run is red on day one |
| MG #23 | Build and test on PRs, three platforms | the reason the rest stayed broken unnoticed |
| RC #10 | CI on PRs, the vendored branch, and Windows | same gap, other repo; its Windows job fails until RC #7 lands |
| MG #19 | `--opt-level`, default `-O2` | independent |
| MG #20 | Cache-domain affinity | independent |

Suggested order: **#18 and RC #7**, then RC #8, then MG #21; **MG #22 before MG
#23**. The rest are independent.

Verified on three platforms: Windows (MSVC + clang), Linux (g++ 15.2, x86_64) and
macOS 26.1 (clang, arm64). The portable pieces - the savestate layout and its
tests, `frontend_config`, `dol_patch` - build and pass on all three. Windows-only
pieces are guarded and their tests registered behind `if(WIN32)`.
