### PR TITLE
Build and test on pull requests, on three platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,115 @@
+name: Build
+
+# Runs on pull requests, which is the point: every failure this was written for
+# reached the default branch without anything checking it, because nothing ran
+# on a PR.
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# A new push supersedes the run in flight. The full job builds Dolphin, which is
+# far too expensive to leave duplicated runs queued.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Everything that needs no Dolphin linkage: the savestate layout, the launcher
+  # helpers, and the config and patch parsing. Minutes rather than the best part
+  # of an hour, so a broken PR is reported quickly and the expensive job is not
+  # the first signal.
+  standalone-tests:
+    name: Standalone tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build the standalone tests
+        shell: bash
+        run: |
+          targets="
+            moderngekko_launcher_savestates_test
+            moderngekko_dol_patch_test
+            moderngekko_frontend_config_test
+            moderngekko_frontend_config_gamecube_test
+          "
+          for target in $targets; do
+            cmake --build build --config Release --target "$target"
+          done
+
+      - name: Test
+        working-directory: build
+        # Named explicitly rather than filtered by prefix. `moderngekko.*` also
+        # matches tests that link Dolphin, which this job deliberately does not
+        # build, and ctest counts an unbuilt test as a failure rather than
+        # skipping it.
+        run: >
+          ctest --output-on-failure --build-config Release
+          -R "moderngekko\.(launcher_savestates|dol_patch|frontend_config)"
+
+  # The whole thing, including everything that links Dolphin. This is the job
+  # that catches a runtime or launcher break, and the one that costs real time.
+  full-build:
+    name: Full build and test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build build-essential pkg-config \
+            libevdev-dev libudev-dev libgtk-3-dev libsystemd-dev \
+            libbluetooth-dev libasound2-dev libpulse-dev libgl1-mesa-dev \
+            libxrandr-dev libxi-dev
+
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        run: choco install ninja --no-progress -y
+
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: runner.os == 'Windows'
+
+      # Dolphin is large enough that a cold build dominates the run. The key
+      # includes the submodule revisions, so a vendored bump correctly misses.
+      - name: Cache compiled objects
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ matrix.os }}-${{ hashFiles('.gitmodules', '**/CMakeLists.txt') }}
+          variant: sccache
+          max-size: 2G
+
+      - name: Configure
+        run: >
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        working-directory: build
+        # fullbench, fuzzer and zstreamtest are vendored zstd's own tests:
+        # registered by its CMake but never built here, so they would always
+        # report "Not Run".
+        run: ctest --output-on-failure --timeout 300 -E "fullbench|fuzzer|zstreamtest"


### PR DESCRIPTION
There is no CI in this repository, and that is why a batch of Windows-only breakage sat unnoticed — three tests crashing (`0xC0000409`) and one target that would not compile. None of it shows on Linux or macOS, and nothing ran on a pull request to say so.

### Two jobs, because the cost is very uneven

**`standalone-tests`** — Windows, Linux and macOS. Builds only what needs no Dolphin linkage: the savestate layout, the launcher helpers, the config and patch parsing. Minutes rather than the best part of an hour, so a broken PR is reported quickly instead of after a full Dolphin build.

**`full-build`** — Windows and Linux. Builds everything and runs the whole suite. This is the job that catches a runtime or launcher break; `sccache` keeps it from being a cold Dolphin build every time, keyed on the submodule revisions so a vendored bump correctly misses the cache.

### Two details that would otherwise bite

**The standalone job names its tests explicitly** rather than filtering on the `moderngekko.` prefix. That prefix also matches tests which link Dolphin — which this job deliberately does not build — and **ctest counts an unbuilt test as a failure rather than skipping it**. Checked against a real build: the prefix selects 26 tests, the explicit list selects the 4 it actually builds. Filtering by prefix would have made the job red on its first run for a reason that had nothing to do with the code.

**`fullbench`, `fuzzer` and `zstreamtest` are excluded.** They are vendored zstd's own tests: registered by its CMake, never built here, so they permanently report "Not Run".

### What I verified, and what I could not

Locally, against a real Windows build: the target names all exist, the ctest filters select what they should, and the YAML parses.

The Linux and macOS legs are **unrehearsed** — neither machine I have access to has `cmake`, so I could not run a configure on them. What I can say is that the sources are portable: the standalone tests compile and pass on Linux (g++ 15.2, x86_64) and macOS 26.1 (clang, arm64) when built directly, and the CMake already handles both (`APPLE` adds `OBJCXX`, non-Windows probes `dlfcn.h`). The first run may still need a fixup.

### Ordering

**#22 should land first.** It is what makes the Windows suite pass; without it the very first CI run is red on day one and everyone learns to ignore the badge.

### How this fits

These land together as a set: savestates working end to end, the Windows build
and test suite being usable at all, and CI so none of it regresses unnoticed.
**This PR is MG #23.**

| | | |
|---|---|---|
| MG #18 | Bump vendored RecompCore | **prerequisite** - without it the launcher cannot compile on Windows (C sources get a C++ PCH) |
| RC #7 | `Interpreter.cpp` include | **prerequisite** - `core` does not compile without it |
| RC #8 | In-game File/View menu and hotkeys | introduces `Core/SavestateLayout.h`, the one definition of where savestates live, what they are called and how they are ordered |
| MG #21 | Launcher savestate picker, `--load-state` | consumes that header, so the launcher and the in-game menu cannot disagree |
| MG #22 | Make the test suite pass on Windows | **land before CI**, or the first run is red on day one |
| MG #23 | Build and test on PRs, three platforms | the reason the rest stayed broken unnoticed |
| RC #10 | CI on PRs, the vendored branch, and Windows | same gap, other repo; its Windows job fails until RC #7 lands |
| MG #19 | `--opt-level`, default `-O2` | independent |
| MG #20 | Cache-domain affinity | independent |

Suggested order: **#18 and RC #7**, then RC #8, then MG #21; **MG #22 before MG
#23**. The rest are independent.

Verified on three platforms: Windows (MSVC + clang), Linux (g++ 15.2, x86_64) and
macOS 26.1 (clang, arm64). The portable pieces - the savestate layout and its
tests, `frontend_config`, `dol_patch` - build and pass on all three. Windows-only
pieces are guarded and their tests registered behind `if(WIN32)`.
