### PR TITLE
Let a run refuse to patch the game it was pointed at

### DIFF
--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -34,7 +34,7 @@ void Usage() {
                " [--game <extracted-root>] [--module <path>]\n"
                "       [--user-dir <path>] [--title <text>]\n"
                "       [--graphics <backend>] [--audio <backend>]\n"
-               "       [--mods <directory>] [--no-mods]\n"
+               "       [--mods <directory>] [--no-mods] [--no-dol-patch]\n"
                "       [--wayland] [-X11] [--headless] [--allow-interpreter]\n"
                "       [--netplay-host | --netplay-join <host>] "
                "[--netplay-port <port>]\n"
@@ -130,6 +130,9 @@ int RunMain(int argc, char **argv) {
 #endif
   std::filesystem::path module_path;
   bool use_default_mods = true;
+  // Patching rewrites the caller's game tree in place, so it needs a way to
+  // be refused.
+  bool apply_dol_patches = true;
   std::optional<moderngekko::frontend::NetplayRole> netplay_role;
   std::string netplay_address;
   std::optional<std::uint16_t> netplay_port;
@@ -161,6 +164,8 @@ int RunMain(int argc, char **argv) {
       config.mod_directories.emplace_back(value("--mods"));
     else if (arg == "--no-mods")
       use_default_mods = false;
+    else if (arg == "--no-dol-patch")
+      apply_dol_patches = false;
     else if (arg == "-X11" || arg == "--x11")
       config.window_system = moderngekko::WindowSystem::X11;
     else if (arg == "--wayland")
@@ -239,17 +244,30 @@ int RunMain(int argc, char **argv) {
   }
 
 #ifdef MODERNGEKKO_DOL_PATCH_MANIFEST
-  bool dol_changed = false;
-  std::string dol_patch_error;
-  if (!moderngekko::frontend::ApplyDolPatchManifest(
-          config.game_root / "sys" / "main.dol",
-          executable_directory / MODERNGEKKO_DOL_PATCH_MANIFEST, &dol_changed,
-          &dol_patch_error)) {
-    std::cerr << "DOL patching failed: " << dol_patch_error << '\n';
-    return 2;
+  const std::filesystem::path dol_path = config.game_root / "sys" / "main.dol";
+  const std::filesystem::path dol_manifest =
+      executable_directory / MODERNGEKKO_DOL_PATCH_MANIFEST;
+  if (apply_dol_patches) {
+    bool dol_changed = false;
+    std::string dol_patch_error;
+    if (!moderngekko::frontend::ApplyDolPatchManifest(
+            dol_path, dol_manifest, &dol_changed, &dol_patch_error)) {
+      std::cerr << "DOL patching failed: " << dol_patch_error << '\n';
+      return 2;
+    }
+    // Name the file that was rewritten and the manifest responsible. This
+    // modifies the game tree the caller supplied, and reporting only that
+    // something happened makes that easy to miss.
+    if (dol_changed) {
+      std::cout << "modified " << dol_path.string() << " from "
+                << dol_manifest.string()
+                << " (pass --no-dol-patch to leave the game unchanged)"
+                << '\n';
+    }
+  } else {
+    std::cout << "skipping DOL patches from " << dol_manifest.string()
+              << '\n';
   }
-  if (dol_changed)
-    std::cout << "Applied native DOL patches\n";
 #endif
   const auto inspected = moderngekko::InspectGame(config.game_root);
   if (!inspected) {


### PR DESCRIPTION
The DOL patch manifest is applied to `<game_root>/sys/main.dol` **in place, on every boot**, with no way to decline:

```cpp
#ifdef MODERNGEKKO_DOL_PATCH_MANIFEST
  ApplyDolPatchManifest(config.game_root / "sys" / "main.dol",
                        executable_directory / MODERNGEKKO_DOL_PATCH_MANIFEST, ...)
#endif
```

Point a branded build at an extracted disc and that disc is modified — not a copy of it, and not only for the duration of the run. The manifest is chosen at build time, so nothing on the command line suggests it will happen.

### How this actually goes wrong

It cost me a reference disc. Bench runs against a project's extracted tree quietly converted it to native widescreen, and every measurement afterwards was of an ultrawide game at 5x internal quality — reading **~30 fps where the unmodified game reads ~65**. Nothing looked broken. The runs completed, frames advanced, standard deviations were tight, the arms compared cleanly. The numbers were simply of a different game than the one I thought I was measuring.

What caught it, a day later, was an unrelated test asserting that the patch cave at `0x80005300` was still free. Without that test the figures would have been published.

### The change

`--no-dol-patch` skips the manifest. Default behaviour is unchanged, and the whole thing stays inside the existing `#ifdef`, so builds without a manifest are unaffected.

The reporting also names what happened. Before:

```
Applied native DOL patches
```

After:

```
modified C:\...\GC6E01\sys\main.dol from C:\...\GC6E01-native-widescreen.csv (pass --no-dol-patch to leave the game unchanged)
```

and, when declined:

```
skipping DOL patches from C:\...\GC6E01-native-widescreen.csv
```

The first message says something happened; the second says which file was rewritten, on whose authority, and how to stop it.

### Verified

Built with a real manifest configured (`-DMODERNGEKKO_DOL_PATCH_MANIFEST=...`) so the `#ifdef` path is live, then run against a copy of a disc with the SHA-256 checked before and after:

| | disc | output |
|---|---|---|
| `--no-dol-patch` | **unchanged** | `skipping DOL patches from ...` |
| default | **rewritten** | `modified ... (pass --no-dol-patch ...)` |

### What I deliberately left alone

Patching a *copy* instead of the caller's tree is the tempting larger fix, but the runtime boots from `game_root`, so it means either duplicating the disc or redirecting the boot path. That is a behavioural change worth its own discussion, not something to smuggle in alongside an opt-out.

Independent of the other open PRs — touches one file and no shared headers.

### How this fits

These land together as a set: savestates working end to end, the Windows build
and test suite being usable at all, and CI so none of it regresses unnoticed.
**This PR is MG #24.**

| | | |
|---|---|---|
| MG #18 | Bump vendored RecompCore | **prerequisite** - without it the launcher cannot compile on Windows (C sources get a C++ PCH) |
| RC #7 | `Interpreter.cpp` include | **prerequisite** - `core` does not compile without it |
| RC #8 | In-game File/View menu and hotkeys | introduces `Core/SavestateLayout.h`, the one definition of where savestates live, what they are called and how they are ordered |
| MG #21 | Launcher savestate picker, `--load-state` | consumes that header, so the launcher and the in-game menu cannot disagree |
| MG #22 | Make the test suite pass on Windows | **land before CI**, or the first run is red on day one |
| MG #23 | Build and test on PRs, three platforms | the reason the rest stayed broken unnoticed |
| RC #10 | CI on PRs, the vendored branch, and Windows | same gap, other repo; its Windows job fails until RC #7 lands |
| MG #24 | `--no-dol-patch` | independent; stops a run silently rewriting the disc it was pointed at |
| MG #19 | `--opt-level`, default `-O2` | independent |
| MG #20 | Cache-domain affinity | independent |

Suggested order: **#18 and RC #7**, then RC #8, then MG #21; **MG #22 before MG
#23**. The rest are independent.

Verified on three platforms: Windows (MSVC + clang), Linux (g++ 15.2, x86_64) and
macOS 26.1 (clang, arm64). The portable pieces - the savestate layout and its
tests, `frontend_config`, `dol_patch` - build and pass on all three. Windows-only
pieces are guarded and their tests registered behind `if(WIN32)`.
