### PR TITLE
Let MODERNGEKKO_STATICRECOMP=0 select Dolphin's JIT on x86-64

### DIFF
--- a/src/runtime/dolphin_runtime.cpp
+++ b/src/runtime/dolphin_runtime.cpp
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
+#include <cstdlib>
 #include <fmt/format.h>
 #include <mutex>
 #include <thread>
@@ -84,6 +85,33 @@ std::string FormatWindowTitle(const std::string &title, double fps) {
   }
   return fmt::format("{} | Net wait {:.1f} ms/s | Buffer {}", formatted_title,
                      s_net_wait_ms_per_second, telemetry.buffer_size);
+}
+
+// StaticRecomp is the default core, and the runtime otherwise pins it
+// unconditionally. Setting MODERNGEKKO_STATICRECOMP=0 selects Dolphin's own JIT
+// instead, which makes the two cores measurable against each other on one
+// build, one host and one savestate.
+//
+// This mirrors MODERNGEKKO_ARM64_STATICRECOMP, which does the same job on
+// arm64. That one has to work inside JitArm64 because there StaticRecomp is the
+// core and the JIT is its fallback; on x86-64 the core itself can simply be
+// swapped, so this stays out of the JIT entirely.
+//
+// The JIT needs no native module, so pair this with --allow-interpreter and no
+// --module. Leaving a module loaded would not change the core selected here,
+// but it would leave the comparison ambiguous about what actually ran.
+PowerPC::CPUCore SelectCPUCore() {
+  static const bool static_recomp = [] {
+    const char *v = std::getenv("MODERNGEKKO_STATICRECOMP");
+    return !v || !*v || *v != '0';
+  }();
+  if (static_recomp)
+    return PowerPC::CPUCore::StaticRecomp;
+#ifdef _M_ARM_64
+  return PowerPC::CPUCore::JITARM64;
+#else
+  return PowerPC::CPUCore::JIT64;
+#endif
 }
 } // namespace
 
@@ -273,7 +301,7 @@ RuntimeCreateResult Runtime::Create(RuntimeConfig config) {
   impl->controllers_initialized = true;
   impl->platform->SetTitle(impl->title);
 
-  Config::SetBase(Config::MAIN_CPU_CORE, PowerPC::CPUCore::StaticRecomp);
+  Config::SetBase(Config::MAIN_CPU_CORE, SelectCPUCore());
   if (!impl->config.graphics.backend.empty())
     Config::SetBase(Config::MAIN_GFX_BACKEND, impl->config.graphics.backend);
   else if (impl->config.headless)


### PR DESCRIPTION
`dolphin_runtime.cpp` pinned `MAIN_CPU_CORE` to `CPUCore::StaticRecomp`
unconditionally, so on x86-64 there was no way to measure a recompiled module
against the JIT it replaces on one build, one host and one savestate.
`--allow-interpreter` only permits starting without a module; it does not select
a core.

This adds a `SelectCPUCore()` gated on `MODERNGEKKO_STATICRECOMP=0`. Default
behaviour is unchanged.

### Why this shape

It mirrors `MODERNGEKKO_ARM64_STATICRECOMP`, which does the same job on arm64.
That one has to work inside `JitArm64` because there StaticRecomp is the core
and the JIT is its fallback, and the two halves of the contract — block linking
and the dispatcher hook — must agree. On x86-64 the core itself can simply be
swapped, so this stays out of the JIT entirely.

Pair it with `--allow-interpreter` and no `--module`. Leaving a module loaded
would not change the core selected here, but it would leave the comparison
ambiguous about what actually ran.

### What it measures

Mario Kart: Double Dash, VS race savestate, Vulkan at 1280x720, frame limiter
disabled, 5 interleaved repeats with a same-session control:

| core | mean fps | SD |
| --- | --- | --- |
| `Jit64` | 321.4 | 13.07 |
| StaticRecomp, module-less (`Jit64`, block linking off) | 79.8 | 0.90 |
| recompiled module, best arm | 67.8 | 1.25 |

The JIT runs **4.74x** the module. The middle row is the useful one: it is the
same JIT under the StaticRecomp contract, and it isolates **4.03x** of that gap
to the contract rather than to generated-code quality. The recompiled module
then sits 15% behind `Jit64`'s own output under the same handicap.

That is consistent with RecompCore #6, which measured 5.88x on the same title on
Apple Silicon against `JitArm64` — a different architecture and a different JIT,
reached a different way. #6 states the tradeoff plainly ("the price of running an
AOT-compiled native module instead of a dynamic recompiler, and it is why the
flag exists"); this makes the same claim checkable on x86-64, where it could not
be reproduced at all before.

### Verification

Confirmed the variable actually switches cores rather than being inert: with the
override off but otherwise identical arguments (module-less,
`--allow-interpreter`), the same build measures 79.8 fps against 321.4 with it
on. A first attempt at that control was invalid — the harness set the variable
itself and overwrote the value under test — so it is worth threading the value
through explicitly if you reproduce this.

Not verified: the JIT arm's rendering output. It is Dolphin's own default core,
so correctness is not really in question, but no screenshot comparison was run.
