### PR TITLE
Include DOLRECOMP_LLVM_WRITE_JOURNAL in the module reuse identity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
             moderngekko_dol_patch_test
             moderngekko_frontend_config_test
             moderngekko_frontend_config_gamecube_test
+            moderngekko_pgo_support_test
+            moderngekko_port_command_line_test
           "
           for target in $targets; do
             cmake --build build --config Release --target "$target"
@@ -57,7 +59,7 @@ jobs:
         # skipping it.
         run: >
           ctest --output-on-failure --build-config Release
-          -R "moderngekko\.(launcher_savestates|dol_patch|frontend_config)"
+          -R "moderngekko\.(launcher_savestates|dol_patch|frontend_config|pgo_support|port_command_line)"
 
   # The whole thing, including everything that links Dolphin. This is the job
   # that catches a runtime or launcher break, and the one that costs real time.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,8 +590,12 @@ if(MODERNGEKKO_ENABLE_DOLPHIN_RUNTIME)
     endif()
     add_dependencies(moderngekko-launcher moderngekko-run)
 
-    add_executable(moderngekko-port tools/moderngekko_port.cpp)
+    add_executable(moderngekko-port
+        tools/moderngekko_port.cpp
+        tools/pgo_support.cpp)
     target_link_libraries(moderngekko-port PRIVATE ModernGekko::Runtime)
+    target_include_directories(moderngekko-port PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/tools")
     target_compile_definitions(moderngekko-port PRIVATE
         MODERNGEKKO_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
     if(DOLRECOMP_ENABLE_LLVM)
@@ -668,6 +672,27 @@ if(BUILD_TESTING)
     target_compile_features(moderngekko_launcher_savestates_test PRIVATE cxx_std_23)
     add_test(NAME moderngekko.launcher_savestates
              COMMAND moderngekko_launcher_savestates_test)
+
+    # The PGO helpers deliberately depend on nothing but the standard library
+    # and the header-only digest, so this runs in the fast cross-platform job
+    # rather than waiting on a Dolphin link.
+    add_executable(moderngekko_pgo_support_test
+        tests/pgo_support_test.cpp
+        tools/pgo_support.cpp)
+    target_include_directories(moderngekko_pgo_support_test PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/tools"
+        "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    target_compile_features(moderngekko_pgo_support_test PRIVATE cxx_std_23)
+    add_test(NAME moderngekko.pgo_support COMMAND moderngekko_pgo_support_test)
+
+    add_executable(moderngekko_port_command_line_test
+        tests/port_command_line_test.cpp
+        tools/pgo_support.cpp)
+    target_include_directories(moderngekko_port_command_line_test PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/tools")
+    target_compile_features(moderngekko_port_command_line_test PRIVATE cxx_std_23)
+    add_test(NAME moderngekko.port_command_line
+             COMMAND moderngekko_port_command_line_test)
 
     add_executable(moderngekko_frontend_config_gamecube_test
         tests/frontend_config_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,18 @@ if(MODERNGEKKO_ENABLE_DOLPHIN_RUNTIME)
     add_subdirectory(vendor/dolphin EXCLUDE_FROM_ALL)
     target_sources(core PRIVATE
         vendor/dolphin/GXRuntime/src/core/cpu_exception.c)
+    # `core` compiles with Dolphin's C++ precompiled header, which MSVC refuses
+    # to apply to a C translation unit (fatal error C1853). Dolphin implements
+    # its shared PCH by hand (Source/PCH: a `use_pch` interface target adding
+    # /Yupch.h /FIpch.h), not via target_precompile_headers, so CMake's
+    # SKIP_PRECOMPILE_HEADERS has no effect here -- /Y- is what turns it off,
+    # and source-level options are emitted after the interface ones.
+    if(MSVC)
+        set_source_files_properties(
+            "${CMAKE_CURRENT_SOURCE_DIR}/vendor/dolphin/GXRuntime/src/core/cpu_exception.c"
+            TARGET_DIRECTORY core
+            PROPERTIES COMPILE_OPTIONS "/Y-")
+    endif()
     target_include_directories(core PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/vendor/dolphin/GXRuntime/include")
     if(MODERNGEKKO_FRONTEND_SDK)
@@ -219,6 +231,11 @@ target_compile_features(moderngekko_dolphin_video PUBLIC cxx_std_23)
 if(MSVC)
     target_compile_options(moderngekko_dolphin_video PUBLIC /Zc:preprocessor)
     target_compile_definitions(moderngekko_dolphin_video PUBLIC UNICODE _UNICODE)
+    # Dolphin's Common/StringUtil.h picks its TStrToUTF8/UTF8ToTStr overloads on
+    # _UNICODE; the non-_UNICODE branch returns a string_view as a std::string
+    # and does not compile. Dolphin's own targets define these, so every target
+    # of ours that includes its headers must too.
+    target_compile_definitions(moderngekko PUBLIC UNICODE _UNICODE)
 endif()
 target_include_directories(moderngekko_dolphin_video
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,20 +122,16 @@ if(MODERNGEKKO_ENABLE_DOLPHIN_RUNTIME)
     set(LINUX_LOCAL_DEV ON CACHE BOOL "" FORCE)
     set(DISTRIBUTOR "ModernGekko" CACHE STRING "" FORCE)
     add_subdirectory(vendor/dolphin EXCLUDE_FROM_ALL)
-    target_sources(core PRIVATE
+    # cpu_exception.c is C, but Dolphin's `core` forces its shared C++
+    # precompiled header (Source/PCH: /Yupch.h /FIpch.h) onto every source in
+    # the target, which MSVC rejects for a C translation unit (C1853), and the
+    # forced include cannot be dropped per-source. It needs nothing but
+    # GXRuntime's core/cpu.h, so give it its own target and link it in.
+    add_library(moderngekko_gxruntime_core STATIC
         vendor/dolphin/GXRuntime/src/core/cpu_exception.c)
-    # `core` compiles with Dolphin's C++ precompiled header, which MSVC refuses
-    # to apply to a C translation unit (fatal error C1853). Dolphin implements
-    # its shared PCH by hand (Source/PCH: a `use_pch` interface target adding
-    # /Yupch.h /FIpch.h), not via target_precompile_headers, so CMake's
-    # SKIP_PRECOMPILE_HEADERS has no effect here -- /Y- is what turns it off,
-    # and source-level options are emitted after the interface ones.
-    if(MSVC)
-        set_source_files_properties(
-            "${CMAKE_CURRENT_SOURCE_DIR}/vendor/dolphin/GXRuntime/src/core/cpu_exception.c"
-            TARGET_DIRECTORY core
-            PROPERTIES COMPILE_OPTIONS "/Y-")
-    endif()
+    target_include_directories(moderngekko_gxruntime_core PUBLIC
+        "${CMAKE_CURRENT_SOURCE_DIR}/vendor/dolphin/GXRuntime/include")
+    target_link_libraries(core PRIVATE moderngekko_gxruntime_core)
     target_include_directories(core PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/vendor/dolphin/GXRuntime/include")
     if(MODERNGEKKO_FRONTEND_SDK)
@@ -254,9 +250,13 @@ target_link_libraries(moderngekko PUBLIC ModernGekko::ABI PRIVATE fmt::fmt)
 if(MODERNGEKKO_ENABLE_DOLPHIN_RUNTIME)
     target_sources(moderngekko PRIVATE
         src/runtime/dolphin_runtime.cpp
+        # Benchmark automation protocol (status.txt + commands/), used by
+        # dolphin_runtime.cpp; the header lives beside it under tools/.
+        tools/automation_protocol.cpp
         vendor/dolphin/Source/Core/DolphinNoGUI/Platform.cpp
         vendor/dolphin/Source/Core/DolphinNoGUI/PlatformHeadless.cpp
     )
+    target_include_directories(moderngekko PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tools")
     if(WIN32)
         target_sources(moderngekko PRIVATE
             vendor/dolphin/Source/Core/DolphinNoGUI/PlatformWin32.cpp)
@@ -422,6 +422,7 @@ if(MODERNGEKKO_ENABLE_DOLPHIN_RUNTIME)
     endif()
     add_executable(moderngekko-run
         tools/moderngekko_run.cpp
+        tools/automation_protocol.cpp
         tools/netplay_compatibility.cpp
         tools/netplay_session.cpp
         tools/frontend_config.cpp

--- a/README.md
+++ b/README.md
@@ -10,6 +10,146 @@ The mod ABI supports dependency ordering, minimum versions, optional dependencie
 
 DolRecomp's optional MAP input emits named address constants for code mods. Literal addresses remain supported when a game has no MAP file. See `mod-template` for a minimal package.
 
+## Profile-guided optimisation
+
+`moderngekko-port pgo-run` builds an instrumented module, runs it so you can play
+a representative workload, merges the profile that produces, and builds the final
+module against it -- in one command.
+
+```bash
+moderngekko-port pgo-run extracted/GM4E01 --backend llvm
+```
+
+### What is being optimised
+
+The profile describes the **generated per-game module**, not `moderngekko-port`.
+The port is a build driver that runs for a few minutes; the module is the
+recompiled game, and it is where every frame is spent. Profiling the tool that
+produced the module would optimise the wrong program.
+
+That is also why training is a real play session rather than a benchmark: the
+profile records which of the game's basic blocks are hot, so it is only as good
+as the gameplay you exercise while it runs.
+
+### Backends
+
+Both module backends are supported, and each needs its instrumentation applied in
+a different place.
+
+- `--backend c` -- DolRecomp emits C, so Clang's own `-fprofile-generate` and
+  `-fprofile-use=` reach the chunks through the module's compile flags.
+- `--backend llvm` -- DolRecomp emits and code-generates IR in-process, so no
+  compile flag ever reaches those chunks. Instrumentation is applied by
+  DolRecomp's own IR-level PGO passes (`DOLRECOMP_LLVM_PGO=gen` / `=use`), which
+  `pgo-run` drives for you. Stale profiles are refused
+  (`DOLRECOMP_LLVM_PGO_STALE=error`) rather than silently degrading to a
+  half-trained module.
+
+In both cases `-fprofile-generate` also reaches the module's **link** line, which
+is where LLVM's profiling runtime comes from. Without it the instrumented module
+writes no profile at all.
+
+### Requirements
+
+Instrumentation PGO needs **Clang** and an **`llvm-profdata` of the same major
+LLVM version**. `--toolchain auto` resolves to Clang for this command; GCC and
+MSVC fail immediately with an explanation rather than quietly producing an
+unprofiled module.
+
+`llvm-profdata` is looked for in this order: `--llvm-profdata`, `$LLVM_PROFDATA`,
+beside the resolved `clang`, `clang --print-prog-name=llvm-profdata`, `xcrun
+--find` on macOS, then `PATH`. A candidate is only accepted if it prints an LLVM
+version banner, and a known major-version mismatch with Clang is a hard error.
+
+### Examples
+
+Interactive, LLVM backend:
+
+```bash
+moderngekko-port pgo-run extracted/GM4E01 --backend llvm
+```
+
+Training from a savestate, with runner options forwarded after `--` exactly as
+`run` forwards them:
+
+```bash
+moderngekko-port pgo-run extracted/GM4E01 \
+    --backend llvm \
+    --profile-dir build/pgo/GM4E01 \
+    -- \
+    --load-state states/race.sav \
+    --graphics Vulkan \
+    --no-mods
+```
+
+C backend:
+
+```bash
+moderngekko-port pgo-run extracted/GM4E01 --backend c --toolchain clang
+```
+
+**Close the game through its own quit path.** The profiling runtime writes the
+`.profraw` when the process shuts down normally; a process that is killed skips
+that flush, and a run that exits nonzero aborts the workflow rather than merging
+whatever happens to be on disk.
+
+### Where things are kept
+
+Everything a run produces lives under `--profile-dir`, or under
+`<output>/<disc-id>/pgo` when that is not given:
+
+```
+<profile-dir>/
+    raw/                 .profraw from the training run
+    generate-modules/    the instrumented module's own private cache
+    merged.profdata      the merged, validated profile
+    pgo-manifest.txt     how the final module was produced
+```
+
+The instrumented module is built into a **private** cache root, so it can never
+be written to the real `active-module.txt`. The PGO module becomes active only
+after every stage has succeeded: instrumented build, clean training exit, raw
+profile discovery, merge, validation, PGO build, and final module validation. If
+any stage fails the command exits nonzero, names the stage, leaves the previously
+active module exactly as it was, and keeps the work files for diagnosis.
+
+`raw/` is emptied at the start of every run, so a profile left by an earlier build
+cannot be merged into this one.
+
+### Cache identity
+
+The module cache key includes the PGO mode (`off`, `generate`, `use`) and, for
+use builds, the **SHA-256 of the merged profile's contents**. That means a plain
+module can never answer a PGO build, an instrumented module can never answer
+either, and two different profiles written to the same scratch filename produce
+different modules. The same profile copied to a different path reuses the
+existing module, because the path is not part of the identity -- only what is in
+the file.
+
+The key also now folds in the code-generation-affecting DolRecomp environment
+variables (`DOLRECOMP_LLVM_CPU`, `DOLRECOMP_LLVM_FEATURES`,
+`DOLRECOMP_LLVM_TARGET`, `DOLRECOMP_LLVM_CHUNK_INSTRUCTIONS`,
+`DOLRECOMP_C_CHUNK_INSTRUCTIONS`, `DOLRECOMP_DISPATCH_LOOKUP`,
+`DOLRECOMP_UNSAFE_DIRECT_CALLS`) when any of them is set, so builds made with
+different code-generation settings stop colliding.
+
+### Keeping the work files
+
+A successful run removes `raw/` and `generate-modules/` once the final module is
+safely published, and always keeps `merged.profdata` and `pgo-manifest.txt`. Pass
+`--keep-work` to keep the raw profiles and the instrumented module too.
+
+### Limitations of this version
+
+- Training is **interactive**. There is no scripted or timed workload, and no
+  title-specific training plan.
+- A representative workload is the developer's responsibility. The profile is
+  only as good as what was played.
+- Clang and a matching `llvm-profdata` are required; there is no GCC or MSVC
+  path.
+- No universal speedup is claimed. The gain depends on the title, the backend,
+  the host architecture, and the training workload.
+
 ## Credits
 
 SpecialK / aharonahdoot - RecompCore (referenced heavily)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ beside the resolved `clang`, `clang --print-prog-name=llvm-profdata`, `xcrun
 --find` on macOS, then `PATH`. A candidate is only accepted if it prints an LLVM
 version banner, and a known major-version mismatch with Clang is a hard error.
 
+**With `--backend llvm` there is a third LLVM to match.** The merged profile is
+written by `llvm-profdata` and read back by the LLVM that DolRecomp itself is
+linked against, and those are separate installations. The pinned recompiler
+builds against **LLVM 19 or 20**, so a distribution whose default `clang` is
+newer will merge a profile the recompiler cannot parse, and the build fails with
+`unsupported instrumentation profile format version` repeated once per chunk.
+
+`pgo-run` cannot check this for you — DolRecomp does not report its own LLVM
+version — so put the matching release first on `PATH`:
+
+```bash
+export PATH=/usr/lib/llvm-20/bin:$PATH
+```
+
+Overriding only `--llvm-profdata` is not enough: the module's C sources are
+compiled by whichever `clang` is on `PATH`, and that clang supplies the
+profiling runtime that writes the raw profile. Check what the recompiler links
+against with `ldd $(which dolrecomp) | grep -i llvm`. The `--backend c` path has
+no recompiler-side profile reader and is unaffected.
+
 ### Examples
 
 Interactive, LLVM backend:

--- a/README.md
+++ b/README.md
@@ -101,10 +101,17 @@ Everything a run produces lives under `--profile-dir`, or under
 ```
 <profile-dir>/
     raw/                 .profraw from the training run
-    generate-modules/    the instrumented module's own private cache
+    gen/                 the instrumented module's own private cache
     merged.profdata      the merged, validated profile
     pgo-manifest.txt     how the final module was produced
 ```
+
+On Windows, note that the generation build nests a second module cache under
+this directory, and a module build path is already close to the 260-character
+limit. `pgo-run` measures the longest path it would need before building
+anything and stops immediately with a message naming `--profile-dir` if it would
+not fit, rather than failing twenty minutes later inside ninja. If you hit it,
+pass something short such as `--profile-dir C:\mg-pgo`.
 
 The instrumented module is built into a **private** cache root, so it can never
 be written to the real `active-module.txt`. The PGO module becomes active only

--- a/include/moderngekko/runtime.hpp
+++ b/include/moderngekko/runtime.hpp
@@ -44,6 +44,11 @@ struct InputSettings
   bool background_input = false;
 };
 
+struct AutomationSettings
+{
+  std::filesystem::path directory;
+};
+
 enum class WindowSystem
 {
   Default,
@@ -68,6 +73,7 @@ struct RuntimeConfig
   std::optional<std::string> window_title;
   // Boot straight into a savestate instead of from the title screen.
   std::optional<std::filesystem::path> load_state_path;
+  AutomationSettings automation;
 };
 
 enum class RuntimeErrorCode

--- a/include/moderngekko/runtime.hpp
+++ b/include/moderngekko/runtime.hpp
@@ -37,6 +37,10 @@ struct GraphicsSettings
 struct AudioSettings
 {
   std::string backend;
+  // Silence output without touching the audio backend or the DSP engine:
+  // savestates record DSP state, so switching to a null backend makes them
+  // refuse to load ("State is incompatible with current DSP engine").
+  bool mute = false;
 };
 
 struct InputSettings

--- a/include/moderngekko/sha256.hpp
+++ b/include/moderngekko/sha256.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+// SHA-256, header-only and dependent on nothing but the standard library.
+//
+// This lived inside src/runtime/game.cpp, which is where the DOL and asset
+// hashes are computed. The PGO workflow needs the same digest for a merged
+// profile, and it has to be able to compute it from a translation unit that
+// does not link the runtime -- the standalone test job builds no Dolphin. A
+// second copy of a hash function is the kind of duplication that stays correct
+// right up until one copy is fixed, so the definition moved here and both
+// callers include it.
+
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace moderngekko
+{
+namespace detail
+{
+inline constexpr std::array<std::uint32_t, 64> SHA256_K = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+inline std::uint32_t ReadBE32(const std::uint8_t* p)
+{
+  return (std::uint32_t{p[0]} << 24) | (std::uint32_t{p[1]} << 16) |
+         (std::uint32_t{p[2]} << 8) | p[3];
+}
+}  // namespace detail
+
+inline std::string Sha256(std::vector<std::uint8_t> data)
+{
+  const std::uint64_t bit_size = static_cast<std::uint64_t>(data.size()) * 8;
+  data.push_back(0x80);
+  while ((data.size() % 64) != 56)
+    data.push_back(0);
+  for (int shift = 56; shift >= 0; shift -= 8)
+    data.push_back(static_cast<std::uint8_t>(bit_size >> shift));
+
+  std::array<std::uint32_t, 8> h = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                                    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+  for (std::size_t offset = 0; offset < data.size(); offset += 64)
+  {
+    std::array<std::uint32_t, 64> w{};
+    for (std::size_t i = 0; i < 16; ++i)
+      w[i] = detail::ReadBE32(data.data() + offset + i * 4);
+    for (std::size_t i = 16; i < 64; ++i)
+    {
+      const auto s0 = std::rotr(w[i - 15], 7) ^ std::rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+      const auto s1 = std::rotr(w[i - 2], 17) ^ std::rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+      w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+    }
+    auto [a, b, c, d, e, f, g, hh] = h;
+    for (std::size_t i = 0; i < 64; ++i)
+    {
+      const auto s1 = std::rotr(e, 6) ^ std::rotr(e, 11) ^ std::rotr(e, 25);
+      const auto ch = (e & f) ^ (~e & g);
+      const auto t1 = hh + s1 + ch + detail::SHA256_K[i] + w[i];
+      const auto s0 = std::rotr(a, 2) ^ std::rotr(a, 13) ^ std::rotr(a, 22);
+      const auto maj = (a & b) ^ (a & c) ^ (b & c);
+      hh = g; g = f; f = e; e = d + t1; d = c; c = b; b = a; a = t1 + s0 + maj;
+    }
+    h[0] += a; h[1] += b; h[2] += c; h[3] += d;
+    h[4] += e; h[5] += f; h[6] += g; h[7] += hh;
+  }
+  std::ostringstream out;
+  out << std::hex << std::setfill('0');
+  for (const auto word : h)
+    out << std::setw(8) << word;
+  return out.str();
+}
+
+inline std::string Sha256(std::string_view data)
+{
+  return Sha256(std::vector<std::uint8_t>(data.begin(), data.end()));
+}
+
+inline std::optional<std::vector<std::uint8_t>> ReadFileBytes(const std::filesystem::path& path)
+{
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  if (!file)
+    return std::nullopt;
+  const auto size = file.tellg();
+  if (size < 0)
+    return std::nullopt;
+  std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
+  file.seekg(0);
+  if (!bytes.empty() && !file.read(reinterpret_cast<char*>(bytes.data()), size))
+    return std::nullopt;
+  return bytes;
+}
+
+// Named apart from the runtime's HashFileSha256 declaration in game.hpp, which
+// this is the implementation of. Callers that already link the runtime should
+// keep using that one.
+inline std::optional<std::string> Sha256File(const std::filesystem::path& path)
+{
+  auto bytes = ReadFileBytes(path);
+  if (!bytes)
+    return std::nullopt;
+  return Sha256(std::move(*bytes));
+}
+}  // namespace moderngekko

--- a/src/runtime/dolphin_runtime.cpp
+++ b/src/runtime/dolphin_runtime.cpp
@@ -187,11 +187,18 @@ void MarkAutomationCommand(RuntimeAutomationState& state, std::string command_na
 
 void ClearAutomationPad(int port)
 {
+  // Pin every control to neutral rather than clearing the override.
+  // ClearControlState REMOVES the override, and Dolphin then falls back to the
+  // real input device -- so the host keyboard reaches the game again. Since
+  // ApplyAutomationPad() calls this first, every pad command silently reopened
+  // host input mid-run, which is how a stray keypress (Enter = START = pause)
+  // wrecked benchmark runs. A neutral override is identical for the guest and
+  // keeps automation authoritative for as long as it is registered.
   for (int control = static_cast<int>(ciface::Touch::FIRST_GC_CONTROL);
        control <= static_cast<int>(ciface::Touch::LAST_GC_CONTROL); ++control)
   {
-    ciface::Touch::ClearControlState(port,
-                                     static_cast<ciface::Touch::ControlID>(control));
+    ciface::Touch::SetControlState(
+        port, static_cast<ciface::Touch::ControlID>(control), 0.0);
   }
 }
 
@@ -641,7 +648,23 @@ RuntimeCreateResult Runtime::Create(RuntimeConfig config) {
   EnsureAutomationDirectories(impl->config.automation.directory);
   if (!impl->config.automation.directory.empty()) {
     for (int port = 0; port < 4; ++port)
+    {
       ciface::Touch::RegisterGameCubeInputOverrider(port);
+      // The overrider returns nullopt for any control automation is not
+      // actively driving, and Dolphin then falls back to the REAL device --
+      // so a stray keypress on the host still reaches the game. (Enter is
+      // Dolphin's default mapping for START, which opens the pause menu and
+      // silently wrecks a benchmark run.) Pin every control to neutral so
+      // nothing falls through; automation pad commands override on top.
+      for (int id = ciface::Touch::FIRST_GC_CONTROL; id <= ciface::Touch::LAST_GC_CONTROL; ++id)
+        ciface::Touch::SetControlState(port, static_cast<ciface::Touch::ControlID>(id), 0.0);
+      // Wii titles read the Wiimote/Nunchuk/Classic controls, which the
+      // GameCube overrider does not cover -- without this a Wii run still
+      // takes host input.
+      ciface::Touch::RegisterWiiInputOverrider(port);
+      for (int id = ciface::Touch::FIRST_WII_CONTROL; id <= ciface::Touch::LAST_WII_CONTROL; ++id)
+        ciface::Touch::SetControlState(port, static_cast<ciface::Touch::ControlID>(id), 0.0);
+    }
     impl->automation_registered = true;
   }
   impl->platform->SetTitle(impl->title);
@@ -675,6 +698,8 @@ RuntimeCreateResult Runtime::Create(RuntimeConfig config) {
         preferred != preferred_backends.end() ? *preferred : BACKEND_NULLSOUND;
   }
   Config::SetBase(Config::MAIN_AUDIO_BACKEND, impl->config.audio.backend);
+  if (impl->config.audio.mute)
+    Config::SetBase(Config::MAIN_AUDIO_VOLUME, 0);
   Config::SetBase(Config::MAIN_INPUT_BACKGROUND_INPUT,
                   impl->config.input.background_input);
 
@@ -716,7 +741,10 @@ Runtime::~Runtime() {
   m_impl->present_hook = {};
   if (m_impl->automation_registered) {
     for (int port = 0; port < 4; ++port)
+    {
       ciface::Touch::UnregisterGameCubeInputOverrider(port);
+      ciface::Touch::UnregisterWiiInputOverrider(port);
+    }
     m_impl->automation_registered = false;
   }
   m_impl->state_hook = {};

--- a/src/runtime/dolphin_runtime.cpp
+++ b/src/runtime/dolphin_runtime.cpp
@@ -19,6 +19,18 @@
 #include "DolphinNoGUI/Platform.h"
 #include "UICommon/UICommon.h"
 #include "VideoCommon/PerformanceMetrics.h"
+#include "VideoCommon/VideoEvents.h"
+#include "VideoCommon/FrameDumper.h"
+#include "Core/HW/Memmap.h"
+#include "Core/State.h"
+#include "InputCommon/ControllerInterface/Touch/InputOverrider.h"
+#include "automation_protocol.hpp"
+
+#include <chrono>
+#include <fstream>
+#include <mutex>
+#include <thread>
+#include <stop_token>
 #include "VideoCommon/VideoConfig.h"
 #include "dolphin_runtime_internal.hpp"
 #include "moderngekko/cpu_state.h"
@@ -133,6 +145,355 @@ Host_CreateGBAHost(std::weak_ptr<HW::GBA::Core>) {
 }
 
 namespace moderngekko {
+// ---- Automation protocol -----------------------------------------------
+// Ported from the benchmark instrumentation that lived only in the Skyward
+// Sword ModernGekko checkout. The harness drives runs through it: commands
+// are dropped as files under <automation-dir>/commands, and status.txt is
+// rewritten every 200ms with fps/speed/frame counts.
+namespace {
+struct RuntimeAutomationState
+{
+  mutable std::mutex mutex;
+  std::atomic<std::uint64_t> frame_count{0};
+  std::atomic<std::uint64_t> present_count{0};
+  std::uint64_t processed_commands = 0;
+  std::string last_command;
+  std::string last_error;
+};
+
+void EnsureAutomationDirectories(const std::filesystem::path& root)
+{
+  if (root.empty())
+    return;
+  std::error_code ec;
+  std::filesystem::create_directories(root / "commands", ec);
+  std::filesystem::create_directories(root / "processed", ec);
+  std::filesystem::create_directories(root / "failed", ec);
+}
+
+void SetAutomationError(RuntimeAutomationState& state, std::string message)
+{
+  std::lock_guard lock(state.mutex);
+  state.last_error = std::move(message);
+}
+
+void MarkAutomationCommand(RuntimeAutomationState& state, std::string command_name)
+{
+  std::lock_guard lock(state.mutex);
+  ++state.processed_commands;
+  state.last_command = std::move(command_name);
+  state.last_error.clear();
+}
+
+void ClearAutomationPad(int port)
+{
+  for (int control = static_cast<int>(ciface::Touch::FIRST_GC_CONTROL);
+       control <= static_cast<int>(ciface::Touch::LAST_GC_CONTROL); ++control)
+  {
+    ciface::Touch::ClearControlState(port,
+                                     static_cast<ciface::Touch::ControlID>(control));
+  }
+}
+
+void ApplyAutomationPad(const automation::PadState& pad)
+{
+  ClearAutomationPad(pad.port);
+  for (std::size_t index = 0; index < pad.controls.size(); ++index)
+  {
+    ciface::Touch::SetControlState(
+        pad.port,
+        static_cast<ciface::Touch::ControlID>(
+            static_cast<int>(ciface::Touch::FIRST_GC_CONTROL) +
+            static_cast<int>(index)),
+        pad.controls[index]);
+  }
+}
+
+std::filesystem::path NormalizeScreenshotPath(const std::filesystem::path& path)
+{
+  if (!path.has_extension())
+    return path.string() + ".png";
+  return path;
+}
+
+void SaveAutomationScreenshot(const std::filesystem::path& path)
+{
+  std::error_code ec;
+  std::filesystem::create_directories(path.parent_path(), ec);
+  const Core::CPUThreadGuard guard(Core::System::GetInstance());
+  if (g_frame_dumper)
+    g_frame_dumper->SaveScreenshot(path.string());
+}
+
+std::optional<RuntimeError> ReadAutomationMemory(const std::filesystem::path& path, u32 address,
+                                                 u32 size)
+{
+  auto& system = Core::System::GetInstance();
+  const Core::CPUThreadGuard guard(system);
+  const u8* source = system.GetMemory().GetPointerForRange(address, size);
+  if (!source)
+  {
+    return RuntimeError{RuntimeErrorCode::InvalidState,
+                        fmt::format("guest range {:#010x}+{} is not readable", address, size)};
+  }
+
+  std::error_code ec;
+  std::filesystem::create_directories(path.parent_path(), ec);
+  if (ec)
+  {
+    return RuntimeError{RuntimeErrorCode::InitializationFailed,
+                        "could not create memory output directory: " + ec.message()};
+  }
+
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  if (!output)
+  {
+    return RuntimeError{RuntimeErrorCode::InitializationFailed,
+                        "could not open memory output file"};
+  }
+  output.write(reinterpret_cast<const char*>(source), size);
+  if (!output)
+  {
+    return RuntimeError{RuntimeErrorCode::InitializationFailed,
+                        "could not write memory output file"};
+  }
+  return {};
+}
+
+std::optional<RuntimeError> WriteAutomationMemory(u32 address,
+                                                  const std::vector<std::uint8_t>& data)
+{
+  auto& system = Core::System::GetInstance();
+  const Core::CPUThreadGuard guard(system);
+  if (!system.GetMemory().GetPointerForRange(address, data.size()))
+  {
+    return RuntimeError{
+        RuntimeErrorCode::InvalidState,
+        fmt::format("guest range {:#010x}+{} is not writable", address, data.size())};
+  }
+  system.GetMemory().CopyToEmu(address, data.data(), data.size());
+  return {};
+}
+
+std::optional<RuntimeError> ApplyAutomationCommand(Runtime& runtime,
+                                                   RuntimeAutomationState& state,
+                                                   const automation::Command& command,
+                                                   std::stop_token stop_token)
+{
+  auto& system = Core::System::GetInstance();
+  switch (command.type)
+  {
+  case automation::CommandType::Pad:
+    ApplyAutomationPad(command.pad);
+    break;
+  case automation::CommandType::PadFrames:
+  {
+    if (Core::GetState(system) != Core::State::Running)
+    {
+      return RuntimeError{RuntimeErrorCode::InvalidState,
+                          "pad_frames requires a running emulated core"};
+    }
+    std::uint64_t first_frame = state.frame_count.load(std::memory_order_relaxed);
+    ApplyAutomationPad(command.pad);
+    while (!stop_token.stop_requested())
+    {
+      const std::uint64_t current_frame =
+          state.frame_count.load(std::memory_order_relaxed);
+      if (current_frame < first_frame)
+        first_frame = current_frame;
+      else if (current_frame - first_frame >= command.frames)
+        break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ClearAutomationPad(command.pad.port);
+    break;
+  }
+  case automation::CommandType::ClearPad:
+    ClearAutomationPad(command.pad.port);
+    break;
+  case automation::CommandType::Pause:
+    if (auto error = runtime.Pause())
+      return error;
+    break;
+  case automation::CommandType::Resume:
+    if (auto error = runtime.Resume())
+      return error;
+    break;
+  case automation::CommandType::SaveState:
+    std::filesystem::create_directories(command.path.parent_path());
+    State::SaveAs(system, command.path.string());
+    break;
+  case automation::CommandType::LoadState:
+    State::LoadAs(system, command.path.string());
+    break;
+  case automation::CommandType::Screenshot:
+    SaveAutomationScreenshot(NormalizeScreenshotPath(command.path));
+    break;
+  case automation::CommandType::ReadMemory:
+    if (auto error = ReadAutomationMemory(command.path, command.address, command.size))
+      return error;
+    break;
+  case automation::CommandType::WriteMemory:
+    if (auto error = WriteAutomationMemory(command.address, command.data))
+      return error;
+    break;
+  case automation::CommandType::Stop:
+    runtime.RequestStop();
+    break;
+  }
+  MarkAutomationCommand(state, command.source_name);
+  return {};
+}
+
+bool AutomationCommandNeedsReadyCore(automation::CommandType type)
+{
+  switch (type)
+  {
+  case automation::CommandType::Pause:
+  case automation::CommandType::Resume:
+  case automation::CommandType::SaveState:
+  case automation::CommandType::LoadState:
+  case automation::CommandType::Screenshot:
+  case automation::CommandType::ReadMemory:
+  case automation::CommandType::WriteMemory:
+  case automation::CommandType::PadFrames:
+    return true;
+  case automation::CommandType::Pad:
+  case automation::CommandType::ClearPad:
+  case automation::CommandType::Stop:
+    return false;
+  }
+  return true;
+}
+
+bool AutomationCoreIsReady()
+{
+  const auto state = Core::GetState(Core::System::GetInstance());
+  return state == Core::State::Running || state == Core::State::Paused;
+}
+
+void MoveAutomationCommand(const std::filesystem::path& source, const std::filesystem::path& root,
+                           const char* destination_directory)
+{
+  std::error_code ec;
+  const std::filesystem::path destination =
+      root / destination_directory / source.filename();
+  std::filesystem::remove(destination, ec);
+  ec.clear();
+  std::filesystem::rename(source, destination, ec);
+  if (ec)
+  {
+    ec.clear();
+    std::filesystem::copy_file(source, destination,
+                               std::filesystem::copy_options::overwrite_existing, ec);
+    if (!ec)
+      std::filesystem::remove(source, ec);
+  }
+}
+
+template <typename ImplT>
+void WriteAutomationStatus(const std::filesystem::path& root, ImplT& impl)
+{
+  automation::Status status;
+  const auto core_state = impl.booted ? Core::GetState(Core::System::GetInstance())
+                                      : Core::State::Uninitialized;
+  status.state = core_state == Core::State::Paused
+                     ? "paused"
+                     : (core_state == Core::State::Running ? "running" : "stopped");
+  status.booted = impl.booted;
+  status.title = impl.title;
+  status.game_id = impl.metadata.disc_id;
+  status.game_name = impl.metadata.game_name;
+  if (impl.booted)
+  {
+    const auto& perf = Core::System::GetInstance().GetPerfMetrics();
+    status.fps = perf.GetFPS();
+    status.vps = perf.GetVPS();
+    status.speed = perf.GetSpeed();
+  }
+  status.frame_count =
+      impl.automation_state.frame_count.load(std::memory_order_relaxed);
+  status.present_count =
+      impl.automation_state.present_count.load(std::memory_order_relaxed);
+  {
+    std::lock_guard lock(impl.automation_state.mutex);
+    status.processed_commands = impl.automation_state.processed_commands;
+    status.last_command = impl.automation_state.last_command;
+    status.last_error = impl.automation_state.last_error;
+  }
+
+  const std::filesystem::path status_path = root / "status.txt";
+  const std::filesystem::path temp_path = root / "status.tmp";
+  std::ofstream output(temp_path, std::ios::binary | std::ios::trunc);
+  output << automation::FormatStatus(status);
+  output.close();
+  std::error_code ec;
+  std::filesystem::rename(temp_path, status_path, ec);
+  if (ec)
+  {
+    ec.clear();
+    std::filesystem::copy_file(temp_path, status_path,
+                               std::filesystem::copy_options::overwrite_existing, ec);
+    std::filesystem::remove(temp_path, ec);
+  }
+}
+
+template <typename ImplT>
+void AutomationLoop(Runtime& runtime, ImplT& impl, std::stop_token stop_token)
+{
+  const std::filesystem::path root = impl.config.automation.directory;
+  if (root.empty())
+    return;
+
+  EnsureAutomationDirectories(root);
+  auto next_status_write = std::chrono::steady_clock::now();
+  while (!stop_token.stop_requested())
+  {
+
+    for (const auto& command_path : automation::ListCommandFiles(root / "commands"))
+    {
+      automation::Command command;
+      std::string error;
+      if (!automation::ParseCommandFile(command_path, &command, &error))
+      {
+        SetAutomationError(impl.automation_state,
+                           command_path.filename().string() + ": " + error);
+        MoveAutomationCommand(command_path, root, "failed");
+        continue;
+      }
+
+      if (AutomationCommandNeedsReadyCore(command.type) && !AutomationCoreIsReady())
+        break;
+
+      if (!command.path.empty())
+        command.path = automation::ResolveControlPath(root, command.path);
+
+      if (auto runtime_error =
+              ApplyAutomationCommand(runtime, impl.automation_state, command, stop_token))
+      {
+        SetAutomationError(impl.automation_state,
+                           command.source_name + ": " + runtime_error->message);
+        MoveAutomationCommand(command_path, root, "failed");
+        continue;
+      }
+
+      MoveAutomationCommand(command_path, root, "processed");
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= next_status_write)
+    {
+      WriteAutomationStatus(root, impl);
+      next_status_write = now + std::chrono::milliseconds(200);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  WriteAutomationStatus(root, impl);
+}
+
+}  // namespace
+
 struct Runtime::Impl {
   RuntimeConfig config;
   GameMetadata metadata;
@@ -144,6 +505,10 @@ struct Runtime::Impl {
   bool controllers_initialized = false;
   bool booted = false;
   std::atomic<bool> running{false};
+  RuntimeAutomationState automation_state;
+  Common::EventHook present_hook;
+  bool automation_registered = false;
+  std::jthread automation_thread;
 };
 
 namespace detail {
@@ -271,6 +636,14 @@ RuntimeCreateResult Runtime::Create(RuntimeConfig config) {
   const WindowSystemInfo wsi = impl->platform->GetWindowSystemInfo();
   UICommon::InitControllers(wsi);
   impl->controllers_initialized = true;
+  // Automation drives the pad through Dolphin's input overrider, which is what
+  // lets the harness hold accelerate for the length of a measured run.
+  EnsureAutomationDirectories(impl->config.automation.directory);
+  if (!impl->config.automation.directory.empty()) {
+    for (int port = 0; port < 4; ++port)
+      ciface::Touch::RegisterGameCubeInputOverrider(port);
+    impl->automation_registered = true;
+  }
   impl->platform->SetTitle(impl->title);
 
   Config::SetBase(Config::MAIN_CPU_CORE, PowerPC::CPUCore::StaticRecomp);
@@ -336,6 +709,16 @@ Runtime::~Runtime() {
     Core::Stop(Core::System::GetInstance());
     Core::Shutdown(Core::System::GetInstance());
   }
+  if (m_impl->automation_thread.joinable()) {
+    m_impl->automation_thread.request_stop();
+    m_impl->automation_thread.join();
+  }
+  m_impl->present_hook = {};
+  if (m_impl->automation_registered) {
+    for (int port = 0; port < 4; ++port)
+      ciface::Touch::UnregisterGameCubeInputOverrider(port);
+    m_impl->automation_registered = false;
+  }
   m_impl->state_hook = {};
   if (m_impl->controllers_initialized)
     UICommon::ShutdownControllers();
@@ -391,6 +774,20 @@ RuntimeRunResult Runtime::Run() {
                          "Dolphin could not boot sys/main.dol"}};
   }
   m_impl->booted = true;
+  // Frame/present counters the harness reads out of status.txt.
+  m_impl->present_hook =
+      GetVideoEvents().after_present_event.Register([this](const PresentInfo &info) {
+        m_impl->automation_state.frame_count.store(info.frame_count,
+                                                   std::memory_order_relaxed);
+        m_impl->automation_state.present_count.store(info.present_count,
+                                                     std::memory_order_relaxed);
+      });
+  if (!m_impl->config.automation.directory.empty()) {
+    m_impl->automation_thread =
+        std::jthread([this](std::stop_token stop_token) {
+          AutomationLoop(*this, *m_impl, std::move(stop_token));
+        });
+  }
   std::jthread title_thread;
   if (!m_impl->config.headless && m_impl->config.show_fps_in_title) {
     title_thread = std::jthread([](std::stop_token stop_token) {

--- a/src/runtime/game.cpp
+++ b/src/runtime/game.cpp
@@ -1,5 +1,7 @@
 #include "moderngekko/game.hpp"
 
+#include "moderngekko/sha256.hpp"
+
 #include <algorithm>
 #include <array>
 #include <bit>
@@ -13,86 +15,14 @@ namespace moderngekko
 {
 namespace
 {
-constexpr std::array<std::uint32_t, 64> K = {
-    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
-    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
-    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
-    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
-    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
-    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
-
-std::uint32_t ReadBE32(const std::uint8_t* p)
-{
-  return (std::uint32_t{p[0]} << 24) | (std::uint32_t{p[1]} << 16) |
-         (std::uint32_t{p[2]} << 8) | p[3];
-}
-
-std::string Sha256(std::vector<std::uint8_t> data)
-{
-  const std::uint64_t bit_size = static_cast<std::uint64_t>(data.size()) * 8;
-  data.push_back(0x80);
-  while ((data.size() % 64) != 56)
-    data.push_back(0);
-  for (int shift = 56; shift >= 0; shift -= 8)
-    data.push_back(static_cast<std::uint8_t>(bit_size >> shift));
-
-  std::array<std::uint32_t, 8> h = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
-                                     0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
-  for (std::size_t offset = 0; offset < data.size(); offset += 64)
-  {
-    std::array<std::uint32_t, 64> w{};
-    for (std::size_t i = 0; i < 16; ++i)
-      w[i] = ReadBE32(data.data() + offset + i * 4);
-    for (std::size_t i = 16; i < 64; ++i)
-    {
-      const auto s0 = std::rotr(w[i - 15], 7) ^ std::rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
-      const auto s1 = std::rotr(w[i - 2], 17) ^ std::rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
-      w[i] = w[i - 16] + s0 + w[i - 7] + s1;
-    }
-    auto [a, b, c, d, e, f, g, hh] = h;
-    for (std::size_t i = 0; i < 64; ++i)
-    {
-      const auto s1 = std::rotr(e, 6) ^ std::rotr(e, 11) ^ std::rotr(e, 25);
-      const auto ch = (e & f) ^ (~e & g);
-      const auto t1 = hh + s1 + ch + K[i] + w[i];
-      const auto s0 = std::rotr(a, 2) ^ std::rotr(a, 13) ^ std::rotr(a, 22);
-      const auto maj = (a & b) ^ (a & c) ^ (b & c);
-      hh = g; g = f; f = e; e = d + t1; d = c; c = b; b = a; a = t1 + s0 + maj;
-    }
-    h[0] += a; h[1] += b; h[2] += c; h[3] += d;
-    h[4] += e; h[5] += f; h[6] += g; h[7] += hh;
-  }
-  std::ostringstream out;
-  out << std::hex << std::setfill('0');
-  for (const auto word : h)
-    out << std::setw(8) << word;
-  return out.str();
-}
-
-std::optional<std::vector<std::uint8_t>> ReadFile(const std::filesystem::path& path)
-{
-  std::ifstream file(path, std::ios::binary | std::ios::ate);
-  if (!file)
-    return std::nullopt;
-  const auto size = file.tellg();
-  if (size < 0)
-    return std::nullopt;
-  std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
-  file.seekg(0);
-  if (!bytes.empty() && !file.read(reinterpret_cast<char*>(bytes.data()), size))
-    return std::nullopt;
-  return bytes;
-}
+// SHA-256 and the whole-file read live in moderngekko/sha256.hpp so the PGO
+// workflow can hash a merged profile without linking the runtime.
+using detail::ReadBE32;
 }  // namespace
 
 std::optional<std::string> HashFileSha256(const std::filesystem::path& path)
 {
-  auto bytes = ReadFile(path);
+  auto bytes = ReadFileBytes(path);
   if (!bytes)
     return std::nullopt;
   return Sha256(std::move(*bytes));
@@ -154,8 +84,8 @@ GameInspectResult InspectGame(const std::filesystem::path& input_root)
     return {{}, "missing sys/main.dol"};
   if (!std::filesystem::is_directory(root / "files"))
     return {{}, "missing files directory"};
-  const auto boot = ReadFile(boot_path);
-  const auto dol = ReadFile(dol_path);
+  const auto boot = ReadFileBytes(boot_path);
+  const auto dol = ReadFileBytes(dol_path);
   if (!boot || boot->size() < 0x60)
     return {{}, "missing or malformed sys/boot.bin"};
   if (!dol || dol->size() < 0x100)

--- a/tests/automation_protocol_test.cpp
+++ b/tests/automation_protocol_test.cpp
@@ -1,0 +1,186 @@
+#include "automation_protocol.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+namespace
+{
+std::filesystem::path MakeTempDirectory()
+{
+  const auto path = std::filesystem::temp_directory_path() /
+                    std::filesystem::path("moderngekko_automation_test");
+  std::error_code ec;
+  std::filesystem::remove_all(path, ec);
+  std::filesystem::create_directories(path, ec);
+  return path;
+}
+}
+
+int main()
+{
+  namespace automation = moderngekko::automation;
+
+  const std::filesystem::path root = MakeTempDirectory();
+  const std::filesystem::path commands = root / "commands";
+  std::filesystem::create_directories(commands);
+
+  {
+    std::ofstream output(commands / "002_pad.txt");
+    output << "# comment\n"
+           << "command=pad\n"
+           << "port=1\n"
+           << "a=1\n"
+           << "main_x=0.5\n"
+           << "main_y=-1\n";
+  }
+  {
+    std::ofstream output(commands / "001_pause.txt");
+    output << "command=pause\n";
+  }
+
+  const auto listed = automation::ListCommandFiles(commands);
+  if (listed.size() != 2 || listed[0].filename() != "001_pause.txt" ||
+      listed[1].filename() != "002_pad.txt")
+  {
+    return 1;
+  }
+
+  automation::Command command;
+  std::string error;
+  if (!automation::ParseCommandFile(commands / "002_pad.txt", &command, &error))
+    return 2;
+  if (command.type != automation::CommandType::Pad || command.pad.port != 1)
+    return 3;
+  if (command.pad.controls[0] != 1.0 || command.pad.controls[14] != 0.5 ||
+      command.pad.controls[15] != -1.0)
+  {
+    return 4;
+  }
+
+  {
+    std::ofstream output(commands / "003_bad.txt");
+    output << "command=pad\nport=0\nunknown=1\n";
+  }
+  error.clear();
+  if (automation::ParseCommandFile(commands / "003_bad.txt", &command, &error) ||
+      error.find("unknown pad field") == std::string::npos)
+  {
+    return 5;
+  }
+
+  automation::Status status;
+  status.state = "running";
+  status.booted = true;
+  status.fps = 60.0;
+  status.frame_count = 120;
+  status.present_count = 121;
+  status.navigation_mode = 2;
+  status.navigation_valid = true;
+  status.navigation_room_id = 3;
+  status.navigation_player_x = -13.0f;
+  status.navigation_player_z = 168.0f;
+  status.navigation_collision_valid = true;
+  status.navigation_collision_base = 0x809f58c0;
+  status.navigation_collision_segments = 184;
+  status.navigation_npc_count = 2;
+  status.navigation_archive = "M1_stadium_1F";
+  status.navigation_location = "Phenac Stadium 1F";
+  status.last_command = "002_pad.txt";
+  const std::string formatted = automation::FormatStatus(status);
+  if (!formatted.contains("state=running\n") ||
+      !formatted.contains("booted=1\n") ||
+      !formatted.contains("frame_count=120\n") ||
+      !formatted.contains("present_count=121\n") ||
+      !formatted.contains("navigation_mode=2\n") ||
+      !formatted.contains("navigation_valid=1\n") ||
+      !formatted.contains("navigation_room_id=3\n") ||
+      !formatted.contains("navigation_player_x=-13\n") ||
+      !formatted.contains("navigation_collision_valid=1\n") ||
+      !formatted.contains("navigation_collision_base=2157926592\n") ||
+      !formatted.contains("navigation_collision_segments=184\n") ||
+      !formatted.contains("navigation_npc_count=2\n") ||
+      !formatted.contains("navigation_archive=M1_stadium_1F\n") ||
+      !formatted.contains("navigation_location=Phenac Stadium 1F\n") ||
+      !formatted.contains("last_command=002_pad.txt\n"))
+  {
+    return 6;
+  }
+
+  {
+    std::ofstream output(commands / "004_read_memory.txt");
+    output << "command=read_memory\n"
+           << "address=0x809e52b0\n"
+           << "size=32\n"
+           << "path=artifacts/player.bin\n";
+  }
+  error.clear();
+  if (!automation::ParseCommandFile(commands / "004_read_memory.txt", &command, &error))
+    return 7;
+  if (command.type != automation::CommandType::ReadMemory ||
+      command.address != 0x809e52b0 || command.size != 32 ||
+      command.path != std::filesystem::path("artifacts/player.bin"))
+  {
+    return 8;
+  }
+
+  {
+    std::ofstream output(commands / "005_bad_memory.txt");
+    output << "command=read_memory\n"
+           << "address=0xfffffff0\n"
+           << "size=32\n"
+           << "path=artifacts/bad.bin\n";
+  }
+  error.clear();
+  if (automation::ParseCommandFile(commands / "005_bad_memory.txt", &command, &error) ||
+      error.find("exceed the guest address space") == std::string::npos)
+  {
+    return 9;
+  }
+
+  {
+    std::ofstream output(commands / "006_write_memory.txt");
+    output << "command=write_memory\n"
+           << "address=0x809e52bc\n"
+           << "data=42 f6 00 00\n";
+  }
+  error.clear();
+  if (!automation::ParseCommandFile(commands / "006_write_memory.txt", &command, &error))
+    return 10;
+  if (command.type != automation::CommandType::WriteMemory ||
+      command.address != 0x809e52bc || command.size != 4 ||
+      command.data != std::vector<std::uint8_t>({0x42, 0xf6, 0x00, 0x00}))
+  {
+    return 11;
+  }
+
+  {
+    std::ofstream output(commands / "007_pad_frames.txt");
+    output << "command=pad_frames\n"
+           << "port=0\n"
+           << "frames=3\n"
+           << "main_y=1\n";
+  }
+  error.clear();
+  if (!automation::ParseCommandFile(commands / "007_pad_frames.txt", &command, &error))
+    return 12;
+  if (command.type != automation::CommandType::PadFrames || command.frames != 3 ||
+      command.pad.port != 0 || command.pad.controls[15] != 1.0)
+  {
+    return 13;
+  }
+
+  {
+    std::ofstream output(commands / "008_bad_pad_frames.txt");
+    output << "command=pad_frames\nport=0\nframes=0\na=1\n";
+  }
+  error.clear();
+  if (automation::ParseCommandFile(commands / "008_bad_pad_frames.txt", &command, &error) ||
+      error.find("frames=1..36000") == std::string::npos)
+  {
+    return 14;
+  }
+
+  std::error_code ec;
+  std::filesystem::remove_all(root, ec);
+  return 0;
+}

--- a/tests/pgo_support_test.cpp
+++ b/tests/pgo_support_test.cpp
@@ -131,8 +131,8 @@ void TestWorkspace()
   Check(derived.root == fs::path("/cache/modules") / "GM4E01" / "pgo",
         "the derived workspace root is not under the output directory and disc ID");
   Check(derived.raw == derived.root / "raw", "raw directory is not under the workspace root");
-  Check(derived.generate_modules == derived.root / "generate-modules",
-        "generate-modules directory is not under the workspace root");
+  Check(derived.generate_modules == derived.root / "gen",
+        "the generation cache is not under the workspace root");
   Check(derived.merged_profile == derived.root / "merged.profdata",
         "merged profile is not under the workspace root");
   Check(derived.manifest == derived.root / "pgo-manifest.txt",
@@ -148,6 +148,33 @@ void TestWorkspace()
         "--profile-dir did not win over the derived location");
   Check(explicit_dir.raw == fs::path("/build/pgo/GM4E01") / "raw",
         "--profile-dir did not carry through to the raw directory");
+}
+
+// This is the check that turns a twenty-minute build failing with "Unable to
+// create file" into an immediate message, so it has to be measured against the
+// real layout rather than a round number.
+void TestModuleObjectPathLength()
+{
+  // The path this was written for. It failed a real GM4E01 build at 260
+  // characters with the old, longer workspace directory name.
+  const std::size_t observed = pgo::LongestModuleObjectPathLength(
+      "C:/Users/douglaswhittingham/mg-pgo-e2e/c/pgo/generate-modules", "GM4E01");
+  Check(observed > pgo::WINDOWS_PATH_LIMIT,
+        "the path that really failed is not reported as too long (" +
+            std::to_string(observed) + ")");
+
+  // A short workspace has to pass, or the check refuses builds that work.
+  const std::size_t shortest = pgo::LongestModuleObjectPathLength("C:/mg/pgo/gen", "GM4E01");
+  Check(shortest <= pgo::WINDOWS_PATH_LIMIT,
+        "a short workspace is reported as too long (" + std::to_string(shortest) + ")");
+
+  // It has to actually depend on the root, or it is a constant in disguise.
+  Check(pgo::LongestModuleObjectPathLength("C:/a", "GM4E01") <
+            pgo::LongestModuleObjectPathLength("C:/aaaaaaaaaa", "GM4E01"),
+        "the estimate does not grow with the cache root");
+  Check(pgo::LongestModuleObjectPathLength("C:/a", "GM4E01") ==
+            pgo::LongestModuleObjectPathLength("C:/a", "RMCE01"),
+        "the estimate changed for an equally long disc ID");
 }
 
 void TestManifest()
@@ -293,6 +320,7 @@ int main()
   TestSummaryParsing();
   TestVersionParsing();
   TestWorkspace();
+  TestModuleObjectPathLength();
   TestManifest();
   TestProfdataCandidates();
   TestPathFormatting();

--- a/tests/pgo_support_test.cpp
+++ b/tests/pgo_support_test.cpp
@@ -1,0 +1,303 @@
+// The PGO workflow's failure modes are quiet ones. A cache key that ignores the
+// profile hands back a plain module for a PGO build and nothing looks wrong; a
+// summary parser that accepts an all-zero profile reports a trained module that
+// was never trained; a raw-profile scan that trips over a space in a path
+// merges nothing and blames the game. None of that needs a game or a display to
+// test, so none of it is left to the end-to-end run.
+#include "pgo_support.hpp"
+
+#include "moderngekko/sha256.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace fs = std::filesystem;
+namespace pgo = moderngekko::pgo;
+
+namespace
+{
+int g_failures = 0;
+
+void Check(bool condition, const std::string& what)
+{
+  if (condition)
+    return;
+  std::cerr << "FAIL: " << what << '\n';
+  ++g_failures;
+}
+
+pgo::PgoBuildOptions UseOptions(const fs::path& profile, const std::string& digest)
+{
+  pgo::PgoBuildOptions options;
+  options.mode = pgo::PgoMode::Use;
+  options.merged_profile = profile;
+  options.merged_profile_sha256 = digest;
+  return options;
+}
+
+void TestCacheIdentity()
+{
+  pgo::PgoBuildOptions off;
+  pgo::PgoBuildOptions generate;
+  generate.mode = pgo::PgoMode::Generate;
+  const auto use = UseOptions("/tmp/merged.profdata", "aaaa");
+
+  const std::string off_key = pgo::PgoCacheIdentity(off);
+  const std::string generate_key = pgo::PgoCacheIdentity(generate);
+  const std::string use_key = pgo::PgoCacheIdentity(use);
+  Check(off_key != generate_key, "PGO off and generate share a cache identity");
+  Check(off_key != use_key, "PGO off and use share a cache identity");
+  Check(generate_key != use_key, "PGO generate and use share a cache identity");
+  Check(off_key == "pgo=off", "PGO off identity is not spelled out: " + off_key);
+
+  // Two different profiles that happen to be written to the same scratch
+  // filename must not be interchangeable.
+  const std::string same_path_a =
+      pgo::PgoCacheIdentity(UseOptions("/tmp/merged.profdata", "aaaa"));
+  const std::string same_path_b =
+      pgo::PgoCacheIdentity(UseOptions("/tmp/merged.profdata", "bbbb"));
+  Check(same_path_a != same_path_b, "two different profiles at one path share a cache identity");
+
+  // The same profile moved elsewhere is the same build, so it must reuse.
+  const std::string moved =
+      pgo::PgoCacheIdentity(UseOptions("D:/somewhere else/merged.profdata", "aaaa"));
+  Check(same_path_a == moved, "the same profile at a different path changed the cache identity");
+
+  pgo::PgoBuildOptions lenient = UseOptions("/tmp/merged.profdata", "aaaa");
+  lenient.reject_stale_profile = false;
+  Check(pgo::PgoCacheIdentity(lenient) != same_path_a,
+        "the stale-profile policy is missing from the cache identity");
+}
+
+void TestSummaryParsing()
+{
+  const pgo::ProfdataSummary good = pgo::ParseProfdataSummary(
+      "Instrumentation level: IR  entry_first = 0\n"
+      "Total functions: 4213\n"
+      "Maximum function count: 918273\n"
+      "Maximum internal block count: 40551\n");
+  Check(static_cast<bool>(good), "a valid summary was rejected: " + good.error);
+  Check(good.total_functions == 4213, "total functions misparsed");
+  Check(good.maximum_function_count == 918273, "maximum function count misparsed");
+
+  // Instrumentation creates a record for every function whether or not it ran,
+  // so records without counts is exactly what an early flush looks like.
+  const pgo::ProfdataSummary empty = pgo::ParseProfdataSummary(
+      "Instrumentation level: IR\n"
+      "Total functions: 4213\n"
+      "Maximum function count: 0\n");
+  Check(!empty, "a profile with a zero maximum count was accepted");
+
+  const pgo::ProfdataSummary no_records = pgo::ParseProfdataSummary(
+      "Total functions: 0\n"
+      "Maximum function count: 0\n");
+  Check(!no_records, "a profile with no function records was accepted");
+
+  const pgo::ProfdataSummary malformed = pgo::ParseProfdataSummary(
+      "Total functions: not-a-number\n"
+      "Maximum function count: 12\n");
+  Check(!malformed, "a malformed summary was accepted");
+
+  const pgo::ProfdataSummary truncated =
+      pgo::ParseProfdataSummary("error: profile.profdata: Malformed profile data\n");
+  Check(!truncated, "an error message was accepted as a summary");
+
+  const pgo::ProfdataSummary missing_maximum =
+      pgo::ParseProfdataSummary("Total functions: 12\n");
+  Check(!missing_maximum, "a summary with no maximum count was accepted");
+}
+
+void TestVersionParsing()
+{
+  Check(pgo::ParseLlvmMajorVersion("clang version 18.1.8") == 18, "clang version misparsed");
+  Check(pgo::ParseLlvmMajorVersion("Homebrew clang version 17.0.6") == 17,
+        "vendor-prefixed clang version misparsed");
+  Check(pgo::ParseLlvmMajorVersion("  LLVM version 16.0.0") == 16,
+        "llvm-profdata version misparsed");
+  Check(!pgo::ParseLlvmMajorVersion("clang: command not found").has_value(),
+        "a non-version string parsed as a version");
+  Check(!pgo::ParseLlvmMajorVersion("").has_value(), "an empty string parsed as a version");
+}
+
+void TestWorkspace()
+{
+  const pgo::Workspace derived = pgo::DeriveWorkspace({}, "/cache/modules", "GM4E01");
+  Check(derived.root == fs::path("/cache/modules") / "GM4E01" / "pgo",
+        "the derived workspace root is not under the output directory and disc ID");
+  Check(derived.raw == derived.root / "raw", "raw directory is not under the workspace root");
+  Check(derived.generate_modules == derived.root / "generate-modules",
+        "generate-modules directory is not under the workspace root");
+  Check(derived.merged_profile == derived.root / "merged.profdata",
+        "merged profile is not under the workspace root");
+  Check(derived.manifest == derived.root / "pgo-manifest.txt",
+        "manifest is not under the workspace root");
+  // The instrumented module cache and the final module must never resolve to
+  // the same place, or a failed run can publish an instrumented module.
+  Check(derived.generate_modules != fs::path("/cache/modules"),
+        "the generation build shares the caller's module cache root");
+
+  const pgo::Workspace explicit_dir =
+      pgo::DeriveWorkspace("/build/pgo/GM4E01", "/cache/modules", "GM4E01");
+  Check(explicit_dir.root == fs::path("/build/pgo/GM4E01"),
+        "--profile-dir did not win over the derived location");
+  Check(explicit_dir.raw == fs::path("/build/pgo/GM4E01") / "raw",
+        "--profile-dir did not carry through to the raw directory");
+}
+
+void TestManifest()
+{
+  auto options = UseOptions("/profiles/merged.profdata", "0123456789abcdef");
+  pgo::ManifestFacts facts;
+  facts.backend = "llvm";
+  facts.clang_version = "clang version 18.1.8";
+  facts.llvm_profdata_version = "LLVM version 18.1.8";
+  facts.raw_profile_count = 3;
+  facts.total_functions = 4213;
+  facts.maximum_function_count = 918273;
+
+  const std::string manifest = pgo::FormatPgoManifest(options, facts);
+  for (const std::string field :
+       {"pgo_mode=use", "pgo_backend=llvm", "pgo_profile_sha256=0123456789abcdef",
+        "pgo_raw_profile_count=3", "pgo_max_function_count=918273", "pgo_stale_policy=error",
+        "clang_version=clang version 18.1.8", "llvm_profdata_version=LLVM version 18.1.8"})
+    Check(manifest.find(field) != std::string::npos, "manifest is missing " + field);
+  Check(manifest.find("pgo_profile_path=") != std::string::npos,
+        "manifest is missing the profile path");
+  Check(!manifest.empty() && manifest.back() == '\n',
+        "manifest block does not end in a newline, so it would run into the next field");
+}
+
+void TestProfdataCandidates()
+{
+  pgo::LlvmProfdataSources sources;
+  sources.explicit_path = "/opt/explicit/llvm-profdata";
+  sources.environment_path = "/opt/env/llvm-profdata";
+  sources.clang_path = "/usr/lib/llvm-18/bin/clang";
+  sources.print_prog_name = "/usr/lib/llvm-18/bin/llvm-profdata-18";
+  sources.xcrun_path = "/Library/Developer/xcrun/llvm-profdata";
+
+  const std::vector<fs::path> candidates = pgo::LlvmProfdataCandidates(sources);
+  Check(candidates.size() >= 6, "not every llvm-profdata source produced a candidate");
+  Check(candidates.front() == sources.explicit_path, "--llvm-profdata is not tried first");
+  Check(candidates[1] == sources.environment_path, "$LLVM_PROFDATA is not tried second");
+  Check(candidates[2].parent_path() == sources.clang_path.parent_path(),
+        "the binary beside clang is not tried third");
+  Check(candidates.back().parent_path().empty(),
+        "the bare PATH lookup is not tried last");
+
+  // An unset source contributes nothing rather than an empty path that would
+  // be probed as if it were a real candidate.
+  pgo::LlvmProfdataSources sparse;
+  sparse.clang_path = "clang";
+  const std::vector<fs::path> sparse_candidates = pgo::LlvmProfdataCandidates(sparse);
+  Check(sparse_candidates.size() == 1,
+        "an unset llvm-profdata source produced a candidate anyway");
+  for (const fs::path& candidate : sparse_candidates)
+    Check(!candidate.empty(), "an empty candidate was produced");
+}
+
+int TestRawProfileDiscovery()
+{
+  // Unique per run: a fixed name races when two runs overlap and inherits
+  // whatever a run that died before cleanup left behind.
+  const fs::path root =
+      fs::temp_directory_path() /
+      ("moderngekko-pgo-support-" +
+       std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  // A space and non-ASCII in the same path: both have broken this on Windows
+  // before, and the workspace sits under a user-chosen directory.
+  const fs::path raw = root / fs::path(std::u8string(u8"raw profiles プレイヤー"));
+  std::error_code ec;
+  fs::create_directories(raw / "nested", ec);
+  if (ec)
+  {
+    std::cerr << "could not create " << raw << ": " << ec.message() << '\n';
+    return 1;
+  }
+
+  std::ofstream(raw / "GM4E01-1234.profraw").put('a');
+  std::ofstream(raw / "GM4E01-5678.profraw").put('b');
+  std::ofstream(raw / "nested" / "GM4E01-9012.profraw").put('c');
+  // Neither of these is a raw profile, and merging either would fail.
+  std::ofstream(raw / "merged.profdata").put('d');
+  std::ofstream(raw / "notes.txt").put('e');
+
+  const std::vector<fs::path> found = pgo::DiscoverRawProfiles(raw);
+  Check(found.size() == 3, "raw-profile discovery found " + std::to_string(found.size()) +
+                               " profiles rather than 3");
+  for (const fs::path& profile : found)
+    Check(profile.extension() == ".profraw",
+          "discovery returned a non-.profraw file: " + pgo::PathText(profile));
+  Check(std::is_sorted(found.begin(), found.end()), "discovery returned an unsorted list");
+
+  // An absent directory is a normal outcome -- the training run wrote nothing --
+  // and must report empty rather than throw.
+  const std::vector<fs::path> missing = pgo::DiscoverRawProfiles(root / "does-not-exist");
+  Check(missing.empty(), "discovery in a missing directory returned entries");
+
+  fs::remove_all(root, ec);
+  return 0;
+}
+
+void TestPathFormatting()
+{
+  const fs::path windows_style = fs::path("C:/Users/a b/pgo") / "merged.profdata";
+  const std::string clang_text = pgo::ClangPathText(windows_style);
+  Check(clang_text.find('\\') == std::string::npos,
+        "ClangPathText emitted a backslash: " + clang_text);
+  Check(clang_text.find("merged.profdata") != std::string::npos,
+        "ClangPathText lost the filename: " + clang_text);
+
+  const fs::path unicode = fs::path(std::u8string(u8"/profiles/プレイヤー/merged.profdata"));
+  const std::string text = pgo::PathText(unicode);
+  const std::u8string expected = unicode.u8string();
+  Check(text == std::string(expected.begin(), expected.end()),
+        "PathText did not round-trip a Unicode path");
+}
+
+void TestModeNames()
+{
+  Check(pgo::PgoModeName(pgo::PgoMode::Off) == "off", "PgoMode::Off has the wrong name");
+  Check(pgo::PgoModeName(pgo::PgoMode::Generate) == "generate",
+        "PgoMode::Generate has the wrong name");
+  Check(pgo::PgoModeName(pgo::PgoMode::Use) == "use", "PgoMode::Use has the wrong name");
+}
+
+// The profile digest is what makes two profiles distinguishable in the cache
+// key, so a digest that does not actually depend on the contents would defeat
+// every check above.
+void TestProfileDigest()
+{
+  Check(moderngekko::Sha256(std::string_view("")) ==
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "SHA-256 of the empty input is wrong");
+  Check(moderngekko::Sha256(std::string_view("abc")) ==
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        "SHA-256 of \"abc\" is wrong");
+  Check(moderngekko::Sha256(std::string_view("profile-a")) !=
+            moderngekko::Sha256(std::string_view("profile-b")),
+        "two different profiles produced the same digest");
+}
+}  // namespace
+
+int main()
+{
+  TestModeNames();
+  TestCacheIdentity();
+  TestSummaryParsing();
+  TestVersionParsing();
+  TestWorkspace();
+  TestManifest();
+  TestProfdataCandidates();
+  TestPathFormatting();
+  TestProfileDigest();
+  if (TestRawProfileDiscovery() != 0)
+    return 1;
+  return g_failures == 0 ? 0 : 1;
+}

--- a/tests/port_command_line_test.cpp
+++ b/tests/port_command_line_test.cpp
@@ -1,0 +1,154 @@
+// pgo-run added a fourth command and three options to a parser that every
+// existing command already goes through. These cases are mostly about what did
+// NOT change: `build` still rejects a stray argument, `run` still forwards one,
+// `--` still stops option parsing, and the pgo-run options do not exist for
+// anything else.
+#include "port_command_line.hpp"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace port = moderngekko::port;
+
+namespace
+{
+int g_failures = 0;
+
+void Check(bool condition, const std::string& what)
+{
+  if (condition)
+    return;
+  std::cerr << "FAIL: " << what << '\n';
+  ++g_failures;
+}
+
+port::CommandLine Parse(std::vector<const char*> arguments,
+                        std::string_view default_backend = "c")
+{
+  return port::ParseCommandLine(static_cast<int>(arguments.size()), arguments.data(),
+                                default_backend);
+}
+
+void TestExistingCommands()
+{
+  const port::CommandLine inspect = Parse({"moderngekko-port", "inspect", "extracted/GM4E01"});
+  Check(static_cast<bool>(inspect), "inspect failed to parse: " + inspect.error);
+  Check(inspect.command == "inspect", "inspect command misparsed");
+  Check(inspect.root == std::filesystem::path("extracted/GM4E01"), "inspect root misparsed");
+  Check(inspect.build.backend == "c", "the default backend was not applied");
+
+  const port::CommandLine build =
+      Parse({"moderngekko-port", "build", "extracted/GM4E01", "--backend", "llvm", "--toolchain",
+             "clang", "--opt-level", "3", "--output", "/modules"});
+  Check(static_cast<bool>(build), "build failed to parse: " + build.error);
+  Check(build.build.backend == "llvm", "--backend misparsed");
+  Check(build.build.toolchain == "clang", "--toolchain misparsed");
+  Check(build.build.opt_level == "3", "--opt-level misparsed");
+  Check(build.build.output == std::filesystem::path("/modules"), "--output misparsed");
+
+  // build has nowhere to forward an argument it does not know, so it must say
+  // so rather than accept it silently.
+  const port::CommandLine stray = Parse({"moderngekko-port", "build", "game", "--load-state"});
+  Check(!stray, "build accepted an option it does not have");
+  Check(stray.error.find("--load-state") != std::string::npos,
+        "the error does not name the offending option: " + stray.error);
+
+  const port::CommandLine incomplete = Parse({"moderngekko-port", "build", "game", "--backend"});
+  Check(!incomplete, "build accepted --backend with no value");
+
+  // run forwards what it does not recognise, with or without the separator.
+  const port::CommandLine run =
+      Parse({"moderngekko-port", "run", "game", "--graphics", "Vulkan"});
+  Check(static_cast<bool>(run), "run failed to parse: " + run.error);
+  Check(run.build.runner_arguments == std::vector<std::string>{"--graphics", "Vulkan"},
+        "run did not forward its unknown arguments");
+
+  const port::CommandLine separated = Parse({"moderngekko-port", "run", "game", "--backend",
+                                             "llvm", "--", "--load-state", "states/race.sav"});
+  Check(separated.build.backend == "llvm", "--backend before -- was not applied");
+  Check(separated.build.runner_arguments ==
+            std::vector<std::string>{"--load-state", "states/race.sav"},
+        "arguments after -- were not forwarded verbatim");
+}
+
+void TestSeparatorStopsOptionParsing()
+{
+  // A runner option that shares a name with one of this tool's own must reach
+  // the runner unchanged once -- has been seen.
+  const port::CommandLine parsed = Parse(
+      {"moderngekko-port", "pgo-run", "game", "--", "--output", "runner-owned", "--keep-work"});
+  Check(static_cast<bool>(parsed), "pgo-run failed to parse: " + parsed.error);
+  Check(parsed.build.output.empty(), "--output after -- was consumed by the port");
+  Check(!parsed.pgo_run.keep_work, "--keep-work after -- was consumed by the port");
+  Check(parsed.build.runner_arguments ==
+            std::vector<std::string>{"--output", "runner-owned", "--keep-work"},
+        "arguments after -- were not forwarded verbatim");
+}
+
+void TestPgoRun()
+{
+  const port::CommandLine parsed =
+      Parse({"moderngekko-port", "pgo-run", "extracted/GM4E01", "--backend", "llvm",
+             "--profile-dir", "build/pgo/GM4E01", "--llvm-profdata", "/opt/llvm/llvm-profdata",
+             "--keep-work", "--", "--load-state", "states/race.sav", "--no-mods"});
+  Check(static_cast<bool>(parsed), "pgo-run failed to parse: " + parsed.error);
+  Check(parsed.command == "pgo-run", "pgo-run command misparsed");
+  Check(parsed.build.backend == "llvm", "pgo-run --backend misparsed");
+  Check(parsed.pgo_run.profile_dir == std::filesystem::path("build/pgo/GM4E01"),
+        "--profile-dir misparsed");
+  Check(parsed.pgo_run.llvm_profdata == std::filesystem::path("/opt/llvm/llvm-profdata"),
+        "--llvm-profdata misparsed");
+  Check(parsed.pgo_run.keep_work, "--keep-work misparsed");
+  Check(parsed.build.runner_arguments ==
+            std::vector<std::string>{"--load-state", "states/race.sav", "--no-mods"},
+        "pgo-run did not forward the runner arguments verbatim");
+  // pgo-run starts with PGO off; the workflow sets generate and use itself, and
+  // a mode arriving from the command line would bypass that sequencing.
+  Check(parsed.build.pgo.mode == moderngekko::pgo::PgoMode::Off,
+        "parsing set a PGO mode of its own");
+
+  // The pgo-run options belong to pgo-run. On build they have nowhere to go,
+  // and on run they must go to the runner rather than be silently swallowed.
+  const port::CommandLine on_build =
+      Parse({"moderngekko-port", "build", "game", "--keep-work"});
+  Check(!on_build, "build accepted --keep-work");
+
+  const port::CommandLine on_run = Parse({"moderngekko-port", "run", "game", "--keep-work"});
+  Check(static_cast<bool>(on_run), "run failed to parse --keep-work: " + on_run.error);
+  Check(on_run.build.runner_arguments == std::vector<std::string>{"--keep-work"},
+        "run swallowed --keep-work instead of forwarding it");
+}
+
+void TestValidation()
+{
+  Check(!Parse({"moderngekko-port", "build", "game", "--backend", "cpp"}),
+        "an unknown backend was accepted");
+  Check(!Parse({"moderngekko-port", "build", "game", "--opt-level", "4"}),
+        "an out-of-range opt level was accepted");
+  Check(!Parse({"moderngekko-port", "build", "game", "--opt-level", "fast"}),
+        "a non-numeric opt level was accepted");
+  Check(static_cast<bool>(Parse({"moderngekko-port", "build", "game", "--opt-level", "0"})),
+        "-O0 was rejected");
+
+  const port::CommandLine unknown = Parse({"moderngekko-port", "frobnicate", "game"});
+  Check(unknown.usage, "an unknown command did not ask for the usage text");
+  const port::CommandLine bare = Parse({"moderngekko-port"});
+  Check(bare.usage, "a bare invocation did not ask for the usage text");
+  const port::CommandLine no_root = Parse({"moderngekko-port", "inspect"});
+  Check(no_root.usage, "a missing game root did not ask for the usage text");
+
+  const port::CommandLine llvm_default =
+      Parse({"moderngekko-port", "build", "game"}, "llvm");
+  Check(llvm_default.build.backend == "llvm", "the build's default backend was not honoured");
+}
+}  // namespace
+
+int main()
+{
+  TestExistingCommands();
+  TestSeparatorStopsOptionParsing();
+  TestPgoRun();
+  TestValidation();
+  return g_failures == 0 ? 0 : 1;
+}

--- a/tools/automation_protocol.cpp
+++ b/tools/automation_protocol.cpp
@@ -1,0 +1,548 @@
+#include "automation_protocol.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+namespace moderngekko::automation
+{
+namespace
+{
+using ciface::Touch::ControlID;
+
+struct PadField
+{
+  std::string_view name;
+  ControlID control;
+  double min_value;
+  double max_value;
+};
+
+constexpr std::array kPadFields = {
+    PadField{"a", ControlID::GCPAD_A_BUTTON, 0.0, 1.0},
+    PadField{"b", ControlID::GCPAD_B_BUTTON, 0.0, 1.0},
+    PadField{"x", ControlID::GCPAD_X_BUTTON, 0.0, 1.0},
+    PadField{"y", ControlID::GCPAD_Y_BUTTON, 0.0, 1.0},
+    PadField{"z", ControlID::GCPAD_Z_BUTTON, 0.0, 1.0},
+    PadField{"start", ControlID::GCPAD_START_BUTTON, 0.0, 1.0},
+    PadField{"dpad_up", ControlID::GCPAD_DPAD_UP, 0.0, 1.0},
+    PadField{"dpad_down", ControlID::GCPAD_DPAD_DOWN, 0.0, 1.0},
+    PadField{"dpad_left", ControlID::GCPAD_DPAD_LEFT, 0.0, 1.0},
+    PadField{"dpad_right", ControlID::GCPAD_DPAD_RIGHT, 0.0, 1.0},
+    PadField{"l", ControlID::GCPAD_L_DIGITAL, 0.0, 1.0},
+    PadField{"r", ControlID::GCPAD_R_DIGITAL, 0.0, 1.0},
+    PadField{"l_analog", ControlID::GCPAD_L_ANALOG, 0.0, 1.0},
+    PadField{"r_analog", ControlID::GCPAD_R_ANALOG, 0.0, 1.0},
+    PadField{"main_x", ControlID::GCPAD_MAIN_STICK_X, -1.0, 1.0},
+    PadField{"main_y", ControlID::GCPAD_MAIN_STICK_Y, -1.0, 1.0},
+    PadField{"c_x", ControlID::GCPAD_C_STICK_X, -1.0, 1.0},
+    PadField{"c_y", ControlID::GCPAD_C_STICK_Y, -1.0, 1.0},
+
+    // Wii controls. Prefixed so they cannot be confused with the GameCube
+    // names above: a Wii title needs wii_a for its A button, and "a" alone
+    // drives a GameCube pad that such a game never reads.
+    PadField{"wii_a", ControlID::WIIMOTE_A_BUTTON, 0.0, 1.0},
+    PadField{"wii_b", ControlID::WIIMOTE_B_BUTTON, 0.0, 1.0},
+    PadField{"wii_1", ControlID::WIIMOTE_ONE_BUTTON, 0.0, 1.0},
+    PadField{"wii_2", ControlID::WIIMOTE_TWO_BUTTON, 0.0, 1.0},
+    PadField{"wii_plus", ControlID::WIIMOTE_PLUS_BUTTON, 0.0, 1.0},
+    PadField{"wii_minus", ControlID::WIIMOTE_MINUS_BUTTON, 0.0, 1.0},
+    PadField{"wii_home", ControlID::WIIMOTE_HOME_BUTTON, 0.0, 1.0},
+    PadField{"wii_dpad_up", ControlID::WIIMOTE_DPAD_UP, 0.0, 1.0},
+    PadField{"wii_dpad_down", ControlID::WIIMOTE_DPAD_DOWN, 0.0, 1.0},
+    PadField{"wii_dpad_left", ControlID::WIIMOTE_DPAD_LEFT, 0.0, 1.0},
+    PadField{"wii_dpad_right", ControlID::WIIMOTE_DPAD_RIGHT, 0.0, 1.0},
+    PadField{"wii_ir_x", ControlID::WIIMOTE_IR_X, -1.0, 1.0},
+    PadField{"wii_ir_y", ControlID::WIIMOTE_IR_Y, -1.0, 1.0},
+    PadField{"nunchuk_c", ControlID::NUNCHUK_C_BUTTON, 0.0, 1.0},
+    PadField{"nunchuk_z", ControlID::NUNCHUK_Z_BUTTON, 0.0, 1.0},
+    PadField{"nunchuk_x", ControlID::NUNCHUK_STICK_X, -1.0, 1.0},
+    PadField{"nunchuk_y", ControlID::NUNCHUK_STICK_Y, -1.0, 1.0},
+};
+
+std::string Trim(std::string_view value)
+{
+  const auto first = value.find_first_not_of(" \t\r\n");
+  if (first == std::string_view::npos)
+    return {};
+  const auto last = value.find_last_not_of(" \t\r\n");
+  return std::string(value.substr(first, last - first + 1));
+}
+
+std::optional<double> ParseDouble(std::string_view value)
+{
+  const std::string text = Trim(value);
+  if (text.empty())
+    return std::nullopt;
+  char* end = nullptr;
+  const double parsed = std::strtod(text.c_str(), &end);
+  if (end != text.c_str() + text.size() || !std::isfinite(parsed))
+    return std::nullopt;
+  return parsed;
+}
+
+std::optional<int> ParsePort(std::string_view value)
+{
+  const std::string text = Trim(value);
+  int parsed = 0;
+  const auto result =
+      std::from_chars(text.data(), text.data() + text.size(), parsed);
+  if (result.ec != std::errc{} || result.ptr != text.data() + text.size() ||
+      parsed < 0 || parsed > 3)
+  {
+    return std::nullopt;
+  }
+  return parsed;
+}
+
+std::optional<std::uint32_t> ParseUnsigned(std::string_view value)
+{
+  std::string text = Trim(value);
+  if (text.empty())
+    return std::nullopt;
+
+  int base = 10;
+  if (text.starts_with("0x") || text.starts_with("0X"))
+  {
+    base = 16;
+    text.erase(0, 2);
+  }
+  if (text.empty())
+    return std::nullopt;
+
+  std::uint32_t parsed = 0;
+  const auto result =
+      std::from_chars(text.data(), text.data() + text.size(), parsed, base);
+  if (result.ec != std::errc{} || result.ptr != text.data() + text.size())
+    return std::nullopt;
+  return parsed;
+}
+
+std::optional<std::vector<std::uint8_t>> ParseHexBytes(std::string_view value)
+{
+  std::string text;
+  text.reserve(value.size());
+  for (const char character : value)
+  {
+    if (character != ' ' && character != '\t' && character != '_' && character != '-')
+      text.push_back(character);
+  }
+  if (text.starts_with("0x") || text.starts_with("0X"))
+    text.erase(0, 2);
+  if (text.empty() || text.size() % 2 != 0)
+    return std::nullopt;
+
+  std::vector<std::uint8_t> bytes;
+  bytes.reserve(text.size() / 2);
+  for (std::size_t offset = 0; offset < text.size(); offset += 2)
+  {
+    unsigned int byte = 0;
+    const auto result =
+        std::from_chars(text.data() + offset, text.data() + offset + 2, byte, 16);
+    if (result.ec != std::errc{} || result.ptr != text.data() + offset + 2)
+      return std::nullopt;
+    bytes.push_back(static_cast<std::uint8_t>(byte));
+  }
+  return bytes;
+}
+
+std::optional<CommandType> ParseCommandType(std::string_view value)
+{
+  const std::string text = Trim(value);
+  if (text == "pad")
+    return CommandType::Pad;
+  if (text == "pad_frames")
+    return CommandType::PadFrames;
+  if (text == "clear_pad")
+    return CommandType::ClearPad;
+  if (text == "pause")
+    return CommandType::Pause;
+  if (text == "resume")
+    return CommandType::Resume;
+  if (text == "save_state")
+    return CommandType::SaveState;
+  if (text == "load_state")
+    return CommandType::LoadState;
+  if (text == "screenshot")
+    return CommandType::Screenshot;
+  if (text == "read_memory")
+    return CommandType::ReadMemory;
+  if (text == "write_memory")
+    return CommandType::WriteMemory;
+  if (text == "stop")
+    return CommandType::Stop;
+  return std::nullopt;
+}
+
+const PadField* FindPadField(std::string_view name)
+{
+  const auto it = std::ranges::find(kPadFields, name, &PadField::name);
+  return it == kPadFields.end() ? nullptr : &*it;
+}
+
+std::map<std::string, std::string> ParseKeyValueLines(const std::filesystem::path& path,
+                                                      std::string* error)
+{
+  std::ifstream input(path);
+  if (!input) {
+    if (error)
+      *error = "could not open command file";
+    return {};
+  }
+
+  std::map<std::string, std::string> values;
+  std::string line;
+  std::size_t line_number = 0;
+  while (std::getline(input, line))
+  {
+    ++line_number;
+    const std::string trimmed = Trim(line);
+    if (trimmed.empty() || trimmed.starts_with('#'))
+      continue;
+    const auto equals = trimmed.find('=');
+    if (equals == std::string::npos)
+    {
+      if (error)
+        *error = "line " + std::to_string(line_number) + " must be key=value";
+      return {};
+    }
+    const std::string key = Trim(trimmed.substr(0, equals));
+    const std::string value = Trim(trimmed.substr(equals + 1));
+    if (key.empty())
+    {
+      if (error)
+        *error = "line " + std::to_string(line_number) + " has an empty key";
+      return {};
+    }
+    values[key] = value;
+  }
+  return values;
+}
+
+bool ParsePadCommand(const std::map<std::string, std::string>& values, Command* command,
+                     bool require_frames, std::string* error)
+{
+  const auto port_it = values.find("port");
+  if (port_it == values.end())
+  {
+    if (error)
+      *error = "pad commands require port=0..3";
+    return false;
+  }
+  const auto port = ParsePort(port_it->second);
+  if (!port)
+  {
+    if (error)
+      *error = "port must be between 0 and 3";
+    return false;
+  }
+
+  command->pad = {};
+  command->pad.port = *port;
+  if (require_frames)
+  {
+    const auto frames_it = values.find("frames");
+    const auto frames =
+        frames_it == values.end() ? std::nullopt : ParseUnsigned(frames_it->second);
+    if (!frames || *frames == 0 || *frames > 36000)
+    {
+      if (error)
+        *error = "pad_frames commands require frames=1..36000";
+      return false;
+    }
+    command->frames = *frames;
+  }
+
+  for (const auto& [key, value] : values)
+  {
+    if (key == "command" || key == "port" || (require_frames && key == "frames"))
+      continue;
+    const PadField* field = FindPadField(key);
+    if (!field)
+    {
+      if (error)
+        *error = "unknown pad field: " + key;
+      return false;
+    }
+    const auto parsed = ParseDouble(value);
+    if (!parsed || *parsed < field->min_value || *parsed > field->max_value)
+    {
+      if (error)
+      {
+        std::ostringstream message;
+        message << key << " must be between " << field->min_value << " and "
+                << field->max_value;
+        *error = message.str();
+      }
+      return false;
+    }
+    const std::size_t index =
+        static_cast<std::size_t>(field->control) -
+        static_cast<std::size_t>(ControlID::FIRST_GC_CONTROL);
+    command->pad.controls[index] = *parsed;
+  }
+  return true;
+}
+
+bool ParseReadMemoryCommand(const std::map<std::string, std::string>& values, Command* command,
+                            std::string* error)
+{
+  constexpr std::uint32_t max_read_size = 16 * 1024 * 1024;
+  for (const auto& [key, value] : values)
+  {
+    if (key != "command" && key != "address" && key != "size" && key != "path")
+    {
+      if (error)
+        *error = "unknown read_memory field: " + key;
+      return false;
+    }
+  }
+
+  const auto address_it = values.find("address");
+  const auto size_it = values.find("size");
+  const auto path_it = values.find("path");
+  if (address_it == values.end() || size_it == values.end() || path_it == values.end() ||
+      Trim(path_it->second).empty())
+  {
+    if (error)
+      *error = "read_memory requires address=<guest address>, size=<bytes>, and path=<file>";
+    return false;
+  }
+
+  const auto address = ParseUnsigned(address_it->second);
+  const auto size = ParseUnsigned(size_it->second);
+  if (!address)
+  {
+    if (error)
+      *error = "address must be an unsigned decimal or 0x-prefixed hexadecimal value";
+    return false;
+  }
+  if (!size || *size == 0 || *size > max_read_size)
+  {
+    if (error)
+      *error = "size must be between 1 and 16777216 bytes";
+    return false;
+  }
+  if (*address > UINT32_MAX - (*size - 1))
+  {
+    if (error)
+      *error = "address and size exceed the guest address space";
+    return false;
+  }
+
+  command->address = *address;
+  command->size = *size;
+  command->path = Trim(path_it->second);
+  return true;
+}
+
+bool ParseWriteMemoryCommand(const std::map<std::string, std::string>& values, Command* command,
+                             std::string* error)
+{
+  constexpr std::size_t max_write_size = 4096;
+  for (const auto& [key, value] : values)
+  {
+    if (key != "command" && key != "address" && key != "data")
+    {
+      if (error)
+        *error = "unknown write_memory field: " + key;
+      return false;
+    }
+  }
+
+  const auto address_it = values.find("address");
+  const auto data_it = values.find("data");
+  if (address_it == values.end() || data_it == values.end())
+  {
+    if (error)
+      *error = "write_memory requires address=<guest address> and data=<hex bytes>";
+    return false;
+  }
+
+  const auto address = ParseUnsigned(address_it->second);
+  const auto data = ParseHexBytes(data_it->second);
+  if (!address)
+  {
+    if (error)
+      *error = "address must be an unsigned decimal or 0x-prefixed hexadecimal value";
+    return false;
+  }
+  if (!data || data->empty() || data->size() > max_write_size)
+  {
+    if (error)
+      *error = "data must contain between 1 and 4096 hexadecimal bytes";
+    return false;
+  }
+  if (*address > UINT32_MAX - static_cast<std::uint32_t>(data->size() - 1))
+  {
+    if (error)
+      *error = "address and data exceed the guest address space";
+    return false;
+  }
+
+  command->address = *address;
+  command->data = *data;
+  command->size = static_cast<std::uint32_t>(data->size());
+  return true;
+}
+}  // namespace
+
+std::filesystem::path ResolveControlPath(const std::filesystem::path& automation_directory,
+                                         const std::filesystem::path& value)
+{
+  return value.is_absolute() ? value : automation_directory / value;
+}
+
+std::vector<std::filesystem::path>
+ListCommandFiles(const std::filesystem::path& commands_directory)
+{
+  std::vector<std::filesystem::path> result;
+  std::error_code ec;
+  if (!std::filesystem::is_directory(commands_directory, ec))
+    return result;
+
+  for (const auto& entry : std::filesystem::directory_iterator(commands_directory, ec))
+  {
+    if (ec)
+      break;
+    if (!entry.is_regular_file(ec))
+      continue;
+    result.push_back(entry.path());
+  }
+
+  std::ranges::sort(result);
+  return result;
+}
+
+bool ParseCommandFile(const std::filesystem::path& path, Command* command, std::string* error)
+{
+  const auto values = ParseKeyValueLines(path, error);
+  if (values.empty())
+  {
+    if (error && error->empty())
+      *error = "command file is empty";
+    return false;
+  }
+
+  const auto command_it = values.find("command");
+  if (command_it == values.end())
+  {
+    if (error)
+      *error = "command=<name> is required";
+    return false;
+  }
+
+  const auto type = ParseCommandType(command_it->second);
+  if (!type)
+  {
+    if (error)
+      *error = "unknown command: " + command_it->second;
+    return false;
+  }
+
+  Command parsed{};
+  parsed.type = *type;
+  parsed.source_name = path.filename().string();
+
+  switch (*type)
+  {
+  case CommandType::Pad:
+    if (!ParsePadCommand(values, &parsed, false, error))
+      return false;
+    break;
+  case CommandType::PadFrames:
+    if (!ParsePadCommand(values, &parsed, true, error))
+      return false;
+    break;
+  case CommandType::ClearPad:
+  {
+    const auto port_it = values.find("port");
+    if (port_it == values.end())
+    {
+      if (error)
+        *error = "clear_pad commands require port=0..3";
+      return false;
+    }
+    const auto port = ParsePort(port_it->second);
+    if (!port)
+    {
+      if (error)
+        *error = "port must be between 0 and 3";
+      return false;
+    }
+    parsed.pad.port = *port;
+    break;
+  }
+  case CommandType::SaveState:
+  case CommandType::LoadState:
+  case CommandType::Screenshot:
+  {
+    const auto path_it = values.find("path");
+    if (path_it == values.end() || Trim(path_it->second).empty())
+    {
+      if (error)
+        *error = "path=<file> is required";
+      return false;
+    }
+    parsed.path = Trim(path_it->second);
+    break;
+  }
+  case CommandType::ReadMemory:
+    if (!ParseReadMemoryCommand(values, &parsed, error))
+      return false;
+    break;
+  case CommandType::WriteMemory:
+    if (!ParseWriteMemoryCommand(values, &parsed, error))
+      return false;
+    break;
+  case CommandType::Pause:
+  case CommandType::Resume:
+  case CommandType::Stop:
+    break;
+  }
+
+  *command = std::move(parsed);
+  return true;
+}
+
+std::string FormatStatus(const Status& status)
+{
+  std::ostringstream output;
+  output << "state=" << status.state << '\n';
+  output << "booted=" << (status.booted ? "1" : "0") << '\n';
+  output << "fps=" << status.fps << '\n';
+  output << "vps=" << status.vps << '\n';
+  output << "speed=" << status.speed << '\n';
+  output << "frame_count=" << status.frame_count << '\n';
+  output << "present_count=" << status.present_count << '\n';
+  output << "title=" << status.title << '\n';
+  output << "game_id=" << status.game_id << '\n';
+  output << "game_name=" << status.game_name << '\n';
+  output << "navigation_mode=" << status.navigation_mode << '\n';
+  output << "navigation_valid=" << (status.navigation_valid ? "1" : "0")
+         << '\n';
+  output << "navigation_room_id=" << status.navigation_room_id << '\n';
+  output << "navigation_player_x=" << status.navigation_player_x << '\n';
+  output << "navigation_player_z=" << status.navigation_player_z << '\n';
+  output << "navigation_facing=" << status.navigation_facing << '\n';
+  output << "navigation_collision_valid="
+         << (status.navigation_collision_valid ? "1" : "0") << '\n';
+  output << "navigation_collision_base=" << status.navigation_collision_base << '\n';
+  output << "navigation_collision_segments="
+         << status.navigation_collision_segments << '\n';
+  output << "navigation_npc_count=" << status.navigation_npc_count << '\n';
+  output << "navigation_archive=" << status.navigation_archive << '\n';
+  output << "navigation_location=" << status.navigation_location << '\n';
+  output << "processed_commands=" << status.processed_commands << '\n';
+  output << "last_command=" << status.last_command << '\n';
+  output << "last_error=" << status.last_error << '\n';
+  return output.str();
+}
+}  // namespace moderngekko::automation

--- a/tools/automation_protocol.hpp
+++ b/tools/automation_protocol.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "InputCommon/ControllerInterface/Touch/InputOverrider.h"
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace moderngekko::automation
+{
+enum class CommandType
+{
+  Pad,
+  PadFrames,
+  ClearPad,
+  Pause,
+  Resume,
+  SaveState,
+  LoadState,
+  Screenshot,
+  ReadMemory,
+  WriteMemory,
+  Stop,
+};
+
+struct PadState
+{
+  int port = 0;
+  // Sized through the Wii range, not just the GameCube one. ApplyAutomationPad
+  // indexes this array straight off FIRST_GC_CONTROL, so a GC-sized array made
+  // every Wiimote and Nunchuk control unreachable -- automation could not press
+  // A on a Wii title's health-warning screen, let alone move the player.
+  std::array<double, ciface::Touch::LAST_WII_CONTROL - ciface::Touch::FIRST_GC_CONTROL + 1>
+      controls{};
+};
+
+struct Command
+{
+  CommandType type = CommandType::Pause;
+  std::string source_name;
+  PadState pad;
+  std::filesystem::path path;
+  std::uint32_t address = 0;
+  std::uint32_t size = 0;
+  std::uint32_t frames = 0;
+  std::vector<std::uint8_t> data;
+};
+
+struct Status
+{
+  std::string state = "stopped";
+  bool booted = false;
+  double fps = 0.0;
+  double vps = 0.0;
+  double speed = 0.0;
+  std::uint64_t frame_count = 0;
+  std::uint64_t present_count = 0;
+  std::string title;
+  std::string game_id;
+  std::string game_name;
+  int navigation_mode = 0;
+  bool navigation_valid = false;
+  unsigned int navigation_room_id = 0;
+  float navigation_player_x = 0.0f;
+  float navigation_player_z = 0.0f;
+  float navigation_facing = 0.0f;
+  bool navigation_collision_valid = false;
+  std::uint32_t navigation_collision_base = 0;
+  std::uint32_t navigation_collision_segments = 0;
+  std::uint32_t navigation_npc_count = 0;
+  std::string navigation_archive;
+  std::string navigation_location;
+  std::uint64_t processed_commands = 0;
+  std::string last_command;
+  std::string last_error;
+};
+
+std::filesystem::path ResolveControlPath(const std::filesystem::path& automation_directory,
+                                         const std::filesystem::path& value);
+std::vector<std::filesystem::path>
+ListCommandFiles(const std::filesystem::path& commands_directory);
+bool ParseCommandFile(const std::filesystem::path& path, Command* command, std::string* error);
+std::string FormatStatus(const Status& status);
+}  // namespace moderngekko::automation

--- a/tools/moderngekko_port.cpp
+++ b/tools/moderngekko_port.cpp
@@ -1,3 +1,6 @@
+#include "pgo_support.hpp"
+#include "port_command_line.hpp"
+
 #include "moderngekko/game.hpp"
 #include "moderngekko/module_abi.h"
 
@@ -12,6 +15,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <map>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -32,21 +36,14 @@ constexpr std::string_view RECOMPCORE_REVISION = "6ed835397d984f2ac8cccb89589ef5
 constexpr std::string_view DOLRECOMP_REVISION =
     "native-llvm-v4";
 
-struct BuildOptions
-{
-  std::string toolchain = "auto";
-  // Empty means "leave the module template's own default alone". Any other
-  // value is forwarded as RECOMPCORE_MODULE_OPT_LEVEL and folded into the
-  // cache key, so an -O3 module cannot collide with an -O2 one.
-  std::string opt_level;
+using moderngekko::port::BuildOptions;
+using moderngekko::port::PgoRunOptions;
+
 #if defined(MODERNGEKKO_DOLRECOMP_LLVM)
-  std::string backend = "llvm";
+constexpr std::string_view DEFAULT_BACKEND = "llvm";
 #else
-  std::string backend = "c";
+constexpr std::string_view DEFAULT_BACKEND = "c";
 #endif
-  fs::path output;
-  std::vector<std::string> runner_arguments;
-};
 
 fs::path DefaultOutput()
 {
@@ -68,19 +65,132 @@ std::string Suffix()
 #endif
 }
 
-std::string Quote(const fs::path& value)
+std::string QuoteText(const std::string& text)
 {
 #if defined(_WIN32)
-  std::string text = value.string();
   return '"' + text + '"';
 #else
-  std::string text = value.string();
   std::string result = "'";
   for (char c : text)
     result += c == '\'' ? "'\\''" : std::string(1, c);
   return result + "'";
 #endif
 }
+
+// UTF-8 throughout. path::string() narrows through the active code page on
+// Windows, so a module cache under a path the code page cannot represent used
+// to reach the compiler as question marks.
+std::string Quote(const fs::path& value)
+{
+  return QuoteText(moderngekko::pgo::PathText(value));
+}
+
+std::string FirstLine(std::string_view text)
+{
+  const std::size_t end = text.find('\n');
+  std::string line(end == std::string_view::npos ? text : text.substr(0, end));
+  while (!line.empty() && (line.back() == '\r' || line.back() == ' '))
+    line.pop_back();
+  return line;
+}
+
+std::string LineContaining(std::string_view text, std::string_view needle)
+{
+  std::size_t start = 0;
+  while (start <= text.size())
+  {
+    const std::size_t end = text.find('\n', start);
+    const std::string_view line =
+        text.substr(start, end == std::string_view::npos ? std::string_view::npos : end - start);
+    if (line.find(needle) != std::string_view::npos)
+      return FirstLine(line);
+    if (end == std::string_view::npos)
+      break;
+    start = end + 1;
+  }
+  return {};
+}
+
+#if defined(_WIN32)
+std::wstring Widen(std::string_view utf8)
+{
+  if (utf8.empty())
+    return {};
+  const int size = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()),
+                                       nullptr, 0);
+  std::wstring wide(static_cast<std::size_t>(size), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), wide.data(), size);
+  return wide;
+}
+
+std::string Narrow(std::wstring_view wide)
+{
+  if (wide.empty())
+    return {};
+  const int size = WideCharToMultiByte(CP_UTF8, 0, wide.data(), static_cast<int>(wide.size()),
+                                       nullptr, 0, nullptr, nullptr);
+  std::string utf8(static_cast<std::size_t>(size), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, wide.data(), static_cast<int>(wide.size()), utf8.data(), size,
+                      nullptr, nullptr);
+  return utf8;
+}
+#endif
+
+// Child processes inherit the process environment, so setting a variable here
+// is how DOLRECOMP_LLVM_PGO and LLVM_PROFILE_FILE reach DolRecomp and the
+// runner without an environment block being threaded through every call. The
+// restore is in the destructor rather than at the end of the happy path
+// because a failed stage returns early, and a leaked DOLRECOMP_LLVM_PGO=gen
+// would instrument every later build in the same shell.
+class ScopedEnvironment
+{
+public:
+  ScopedEnvironment() = default;
+  ScopedEnvironment(const ScopedEnvironment&) = delete;
+  ScopedEnvironment& operator=(const ScopedEnvironment&) = delete;
+
+  ~ScopedEnvironment()
+  {
+    for (const auto& [name, value] : m_saved)
+      Write(name, value.value_or(std::string{}));
+  }
+
+  void Set(const std::string& name, const std::string& value)
+  {
+    if (!m_saved.contains(name))
+      m_saved.emplace(name, Read(name));
+    Write(name, value);
+  }
+
+private:
+  static std::optional<std::string> Read(const std::string& name)
+  {
+#if defined(_WIN32)
+    if (const wchar_t* value = _wgetenv(Widen(name).c_str()))
+      return Narrow(value);
+#else
+    if (const char* value = std::getenv(name.c_str()))
+      return std::string(value);
+#endif
+    return std::nullopt;
+  }
+
+  // An empty value removes the variable on both platforms, which is what the
+  // restore of a previously unset variable needs.
+  static void Write(const std::string& name, const std::string& value)
+  {
+#if defined(_WIN32)
+    _wputenv_s(Widen(name).c_str(), Widen(value).c_str());
+#else
+    if (value.empty())
+      unsetenv(name.c_str());
+    else
+      setenv(name.c_str(), value.c_str(), 1);
+#endif
+  }
+
+  std::map<std::string, std::optional<std::string>> m_saved;
+};
 
 std::uint64_t Fnv1a(std::string_view value)
 {
@@ -277,7 +387,7 @@ bool PatchDol(const fs::path& input_path, const fs::path& output_path,
 std::string ReadCommand(const std::string& command)
 {
 #if defined(_WIN32)
-  FILE* pipe = _popen(command.c_str(), "r");
+  FILE* pipe = _wpopen(Widen(command).c_str(), L"r");
 #else
   FILE* pipe = popen(command.c_str(), "r");
 #endif
@@ -299,12 +409,13 @@ bool RunCommand(const std::string& command)
 {
   std::cout << "+ " << command << '\n';
 #if defined(_WIN32)
-  std::vector<char> command_line(command.begin(), command.end());
-  command_line.push_back('\0');
-  STARTUPINFOA startup{};
+  std::wstring wide = Widen(command);
+  std::vector<wchar_t> command_line(wide.begin(), wide.end());
+  command_line.push_back(L'\0');
+  STARTUPINFOW startup{};
   startup.cb = sizeof(startup);
   PROCESS_INFORMATION process{};
-  if (!CreateProcessA(nullptr, command_line.data(), nullptr, nullptr, TRUE, 0, nullptr, nullptr,
+  if (!CreateProcessW(nullptr, command_line.data(), nullptr, nullptr, TRUE, 0, nullptr, nullptr,
                       &startup, &process))
   {
     std::cerr << "failed to launch command: Windows error " << GetLastError() << '\n';
@@ -330,6 +441,34 @@ fs::path SiblingExecutable(const char* argv0, std::string name)
 #endif
   const fs::path sibling = self.parent_path() / name;
   return fs::is_regular_file(sibling) ? sibling : fs::path(std::move(name));
+}
+
+// DolRecomp reads these from the ambient environment and they change the code
+// it generates, but none of them were in the module cache key: a module built
+// with DOLRECOMP_LLVM_CPU=znver3 answered a later build with the variable
+// unset. The names are the pinned recompiler's own getenv calls -- the PGO
+// three are excluded because this tool sets them itself, and the profile
+// belongs in the key by content rather than by path.
+//
+// Nothing is contributed when none are set, so a default environment keeps the
+// cache entries it already has.
+std::string DolRecompCodegenIdentity()
+{
+  constexpr std::array<const char*, 7> names = {
+      "DOLRECOMP_C_CHUNK_INSTRUCTIONS", "DOLRECOMP_LLVM_CHUNK_INSTRUCTIONS",
+      "DOLRECOMP_LLVM_CPU",             "DOLRECOMP_LLVM_FEATURES",
+      "DOLRECOMP_LLVM_TARGET",          "DOLRECOMP_DISPATCH_LOOKUP",
+      "DOLRECOMP_UNSAFE_DIRECT_CALLS"};
+  std::string identity;
+  for (const char* name : names)
+  {
+    const char* value = std::getenv(name);
+    if (!value)
+      continue;
+    identity += identity.empty() ? "|dolrecomp_env=" : ",";
+    identity += std::string(name) + "=" + value;
+  }
+  return identity;
 }
 
 std::string PlatformName(moderngekko::GamePlatform platform)
@@ -483,13 +622,41 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
   {
     flags = opt == "0" ? "compile:/Od /fp:strict" : "compile:/O2 /fp:strict";
   }
+
+  // -fprofile-generate has to reach the link and not only the compiles: the
+  // profiling runtime that writes the .profraw comes from the link line, and an
+  // instrumented module that never linked it produces no profile at all. For
+  // the LLVM backend the chunks arrive as objects DolRecomp already
+  // instrumented, so the link is the only place these flags matter to them.
+  std::string pgo_compile_flags;
+  if (options.pgo.mode == moderngekko::pgo::PgoMode::Generate)
+  {
+    pgo_compile_flags = "-fprofile-generate";
+  }
+  else if (options.pgo.mode == moderngekko::pgo::PgoMode::Use)
+  {
+    pgo_compile_flags =
+        "-fprofile-use=" + moderngekko::pgo::ClangPathText(options.pgo.merged_profile);
+    // A profile that no longer describes the code is the exact failure this
+    // workflow exists to avoid measuring through, so it is an error.
+    // -Wprofile-instr-unprofiled is not the same thing: a training run that
+    // never entered a function is normal, and there are thousands of them.
+    pgo_compile_flags += " -Wno-profile-instr-unprofiled";
+    if (options.pgo.reject_stale_profile)
+      pgo_compile_flags += " -Werror=profile-instr-out-of-date";
+  }
+
   const std::string identity = std::string(RECOMPCORE_REVISION) + "|dolrecomp=" +
       std::string(DOLRECOMP_REVISION) + "|module-abi=" +
       std::to_string(MODERNGEKKO_MODULE_ABI_VERSION) + "|cpu-abi=" +
       std::to_string(MODERNGEKKO_CPU_ABI_VERSION) + "|" + compiler_identity + "|" +
       std::string(architecture) + "|" + flags + "|backend=" + options.backend +
       "|patches=" + patches.fingerprint + "|dolrecomp_binary=" +
-      *dolrecomp_hash;
+      *dolrecomp_hash + "|" + moderngekko::pgo::PgoCacheIdentity(options.pgo) +
+      DolRecompCodegenIdentity();
+  // Deliberately NOT pgo_compile_flags: those carry the workspace path the
+  // profile happens to sit at, and the same profile copied elsewhere is the
+  // same build. PgoCacheIdentity carries the profile's content digest instead.
   std::ostringstream key_tail;
   key_tail << std::hex << std::setfill('0') << std::setw(16) << Fnv1a(identity);
   const std::string cache_key = game.dol_sha256 + "-" + key_tail.str();
@@ -521,6 +688,8 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
              << "flags=" << flags << '\n'
              << "backend=" << options.backend << '\n'
              << "patches=" << patches.fingerprint << '\n';
+    if (options.pgo.mode != moderngekko::pgo::PgoMode::Off)
+      manifest << moderngekko::pgo::FormatPgoManifest(options.pgo, options.pgo_facts);
     fs::create_directories(options.output / game.disc_id);
     std::ofstream active(options.output / game.disc_id / "active-module.txt");
     active << module.string() << '\n';
@@ -544,6 +713,26 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
     std::cout << "applied " << patches.entries.size() << " default DOL patches\n";
   }
   const fs::path generated_parent = artifact / "dolrecomp-output";
+  // The LLVM backend emits and codegens IR in-process, so no CFLAGS reach its
+  // chunks; its instrumentation is two passes selected by these variables. The
+  // C backend needs none of this -- its chunks are C, and -fprofile-generate
+  // in CMAKE_C_FLAGS below already covers them.
+  ScopedEnvironment recompiler_environment;
+  if (options.backend == "llvm")
+  {
+    if (options.pgo.mode == moderngekko::pgo::PgoMode::Generate)
+    {
+      recompiler_environment.Set("DOLRECOMP_LLVM_PGO", "gen");
+    }
+    else if (options.pgo.mode == moderngekko::pgo::PgoMode::Use)
+    {
+      recompiler_environment.Set("DOLRECOMP_LLVM_PGO", "use");
+      recompiler_environment.Set("DOLRECOMP_LLVM_PROFILE",
+                                 moderngekko::pgo::PathText(options.pgo.merged_profile));
+      recompiler_environment.Set("DOLRECOMP_LLVM_PGO_STALE",
+                                 options.pgo.reject_stale_profile ? "error" : "warn");
+    }
+  }
   std::string generate = Quote(dolrecomp) + " -j" +
                          std::to_string(std::max(1u, std::thread::hardware_concurrency())) +
                          " --backend=" + options.backend + " ";
@@ -598,6 +787,16 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
            : " -DRECOMPCORE_MODULE_OPT_LEVEL=" + options.opt_level) +
       " -DCHASSIS_ABI_DIR=" +
       Quote(source_root / "vendor/dolphin/Source/Core/Core/PowerPC/StaticRecomp");
+  // The module template has no hook of its own for extra flags, and CMake's
+  // shared-library link rule expands CMAKE_C_FLAGS as well as the linker
+  // flags, so setting both is what puts -fprofile-generate on the compile
+  // lines and on the link line. The linker variable is set explicitly rather
+  // than relied on implicitly, because "it happens to be on the link line
+  // too" is not a property worth depending on for the one flag that has to be
+  // there.
+  if (!pgo_compile_flags.empty())
+    configure += " -DCMAKE_C_FLAGS=" + QuoteText(pgo_compile_flags) +
+                 " -DCMAKE_SHARED_LINKER_FLAGS=" + QuoteText(pgo_compile_flags);
   if (!RunCommand(configure) ||
       !RunCommand("cmake --build " + Quote(module_build) + " -j" +
                   std::to_string(compile_jobs)))
@@ -611,61 +810,317 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
   return publish_module();
 }
 
+fs::path ResolveExecutable(const std::string& name)
+{
+#if defined(_WIN32)
+  const std::string located = FirstLine(ReadCommand("where " + name + " 2>NUL"));
+#else
+  const std::string located = FirstLine(ReadCommand("command -v " + name + " 2>/dev/null"));
+#endif
+  return located.empty() ? fs::path(name) : fs::path(located);
+}
+
+// Every failure exit goes through here, so the two things that must be true of
+// a failed run -- a nonzero status, and an active module that is still the
+// user's -- are stated once instead of at eight return sites.
+int PgoFailure(std::string_view stage, const moderngekko::pgo::Workspace& workspace)
+{
+  std::cerr << "\nPGO run failed during: " << stage << '\n'
+            << "The previously active module is unchanged; no instrumented module was "
+               "published.\n"
+            << "Work files kept for diagnosis: " << workspace.root << '\n';
+  return 1;
+}
+
+int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
+           const PgoRunOptions& pgo_options)
+{
+  const auto inspected = moderngekko::InspectGame(root);
+  if (!inspected)
+  {
+    std::cerr << "invalid extracted game: " << inspected.error << '\n';
+    return 1;
+  }
+  const auto& game = *inspected.metadata;
+
+  // Instrumentation PGO is Clang's. GCC writes .gcda that llvm-profdata cannot
+  // merge, MSVC's PGO is a different mechanism again, and DolRecomp's LLVM
+  // backend applies an LLVM .profdata or nothing. Falling back would produce a
+  // module that builds, runs, and is not profiled.
+  if (options.toolchain == "auto")
+    options.toolchain = "clang";
+  if (options.toolchain != "clang")
+  {
+    std::cerr << "pgo-run requires Clang and a matching llvm-profdata; --toolchain "
+              << options.toolchain << " cannot produce an instrumented module.\n"
+              << "Use --toolchain clang, or `build` for a non-PGO module.\n";
+    return 2;
+  }
+
+  const std::string clang_identity = ReadCommand("clang --version 2>&1");
+  const std::string clang_version = FirstLine(clang_identity);
+  if (clang_version.empty())
+  {
+    std::cerr << "clang is unavailable, and pgo-run requires it\n";
+    return 1;
+  }
+  const fs::path clang_path = ResolveExecutable("clang");
+
+  moderngekko::pgo::LlvmProfdataSources sources;
+  sources.explicit_path = pgo_options.llvm_profdata;
+  if (const char* from_environment = std::getenv("LLVM_PROFDATA"))
+    sources.environment_path = from_environment;
+  sources.clang_path = clang_path;
+  sources.print_prog_name = FirstLine(ReadCommand("clang --print-prog-name=llvm-profdata"));
+#if defined(__APPLE__)
+  sources.xcrun_path = FirstLine(ReadCommand("xcrun --find llvm-profdata 2>/dev/null"));
+#endif
+
+  fs::path llvm_profdata;
+  std::string llvm_profdata_version;
+  for (const fs::path& candidate : moderngekko::pgo::LlvmProfdataCandidates(sources))
+  {
+    // A candidate that does not exist still produces output -- the shell's own
+    // "not found" -- so a nonempty result is not proof. Only a version banner
+    // LLVM itself printed is.
+    const std::string probe = ReadCommand(Quote(candidate) + " --version 2>&1");
+    const std::string banner = LineContaining(probe, "LLVM version");
+    if (banner.empty())
+      continue;
+    llvm_profdata = candidate;
+    llvm_profdata_version = banner;
+    break;
+  }
+  if (llvm_profdata.empty())
+  {
+    std::cerr << "could not find a usable llvm-profdata.\n"
+                 "Pass --llvm-profdata <path>, set LLVM_PROFDATA, or put it on PATH.\n";
+    return 1;
+  }
+
+  const auto clang_major = moderngekko::pgo::ParseLlvmMajorVersion(clang_identity);
+  const auto profdata_major = moderngekko::pgo::ParseLlvmMajorVersion(llvm_profdata_version);
+  // Only a version that both tools reported and that disagrees is refused. An
+  // unparseable banner means the check does not apply, not that it failed.
+  if (clang_major && profdata_major && *clang_major != *profdata_major)
+  {
+    std::cerr << "llvm-profdata is LLVM " << *profdata_major << " but clang is LLVM "
+              << *clang_major << ".\n"
+              << "  clang:         " << clang_version << '\n'
+              << "  llvm-profdata: " << llvm_profdata_version << " (" << llvm_profdata << ")\n"
+              << "The profile formats are not guaranteed compatible across major versions.\n"
+                 "Pass --llvm-profdata with the matching binary.\n";
+    return 1;
+  }
+
+  if (options.output.empty())
+    options.output = DefaultOutput();
+  const moderngekko::pgo::Workspace workspace =
+      moderngekko::pgo::DeriveWorkspace(pgo_options.profile_dir, options.output, game.disc_id);
+
+  std::error_code ec;
+  // A .profraw left by an earlier run describes an earlier module. Merged in,
+  // it trains this one on code that may no longer exist, and the result still
+  // looks like a successful run -- so the raw directory starts empty every
+  // time rather than being appended to.
+  fs::remove_all(workspace.raw, ec);
+  fs::create_directories(workspace.raw, ec);
+  if (ec)
+  {
+    std::cerr << "could not prepare " << workspace.raw << ": " << ec.message() << '\n';
+    return 1;
+  }
+  fs::create_directories(workspace.generate_modules, ec);
+
+  std::cout << "PGO workspace: " << workspace.root << "\n"
+            << "clang:         " << clang_version << "\n"
+            << "llvm-profdata: " << llvm_profdata_version << " (" << llvm_profdata << ")\n";
+
+  std::cout << "\n[1/6] Building the instrumented module\n";
+  BuildOptions generate_options = options;
+  // A private cache root. The generation build must not be able to write the
+  // real active-module.txt, or a failure after this point leaves the user
+  // pointed at an instrumented module.
+  generate_options.output = workspace.generate_modules;
+  generate_options.pgo.mode = moderngekko::pgo::PgoMode::Generate;
+  const auto instrumented = Build(argv0, root, generate_options);
+  if (!instrumented)
+    return PgoFailure("instrumented module build", workspace);
+
+  std::cout << "\n[2/6] PGO training has started.\n"
+               "Exercise representative gameplay, demanding scenes, menus, and transitions.\n"
+               "Close the game normally when training is complete.\n\n";
+  {
+    ScopedEnvironment training_environment;
+    // %p is the training process's pid. Without it a second process -- or a
+    // relaunch inside one session -- overwrites the first one's profile
+    // instead of adding to it.
+    training_environment.Set(
+        "LLVM_PROFILE_FILE",
+        moderngekko::pgo::PathText(workspace.raw / (game.disc_id + "-%p.profraw")));
+    std::string run = Quote(SiblingExecutable(argv0, "moderngekko-run")) + " --game " +
+                      Quote(root) + " --module " + Quote(*instrumented);
+    for (const std::string& arg : options.runner_arguments)
+      run += " " + Quote(arg);
+    if (!RunCommand(run))
+    {
+      std::cerr << "\nthe training run exited with a failure status.\n"
+                   "The profiling runtime flushes on a normal shutdown, so a crashed or "
+                   "killed run has not written a usable profile.\n";
+      return PgoFailure("training run", workspace);
+    }
+  }
+
+  std::cout << "\n[3/6] Collecting raw profiles\n";
+  const std::vector<fs::path> raw_profiles =
+      moderngekko::pgo::DiscoverRawProfiles(workspace.raw);
+  std::uintmax_t raw_bytes = 0;
+  std::size_t nonempty = 0;
+  for (const fs::path& profile : raw_profiles)
+  {
+    const std::uintmax_t size = fs::file_size(profile, ec);
+    if (ec)
+      continue;
+    raw_bytes += size;
+    if (size > 0)
+      ++nonempty;
+  }
+  if (nonempty == 0)
+  {
+    std::cerr << "no nonempty .profraw was written to " << workspace.raw << ".\n"
+              << "The instrumented module did not flush a profile. Close the game through "
+                 "its own quit path rather than killing it.\n";
+    return PgoFailure("raw-profile discovery", workspace);
+  }
+
+  std::cout << "\n[4/6] Merging profiles\n";
+  std::string merge =
+      Quote(llvm_profdata) + " merge -output=" + Quote(workspace.merged_profile);
+  for (const fs::path& profile : raw_profiles)
+    merge += " " + Quote(profile);
+  if (!RunCommand(merge))
+    return PgoFailure("profile merge", workspace);
+  const std::uintmax_t merged_size = fs::file_size(workspace.merged_profile, ec);
+  if (ec || merged_size == 0)
+  {
+    std::cerr << "llvm-profdata reported success but produced no usable "
+              << workspace.merged_profile << '\n';
+    return PgoFailure("profile merge", workspace);
+  }
+
+  std::cout << "\n[5/6] Validating the merged profile\n";
+  const std::string shown =
+      ReadCommand(Quote(llvm_profdata) + " show " + Quote(workspace.merged_profile) + " 2>&1");
+  const moderngekko::pgo::ProfdataSummary summary =
+      moderngekko::pgo::ParseProfdataSummary(shown);
+  if (!summary)
+  {
+    std::cerr << summary.error << "\nllvm-profdata show said:\n" << shown << '\n';
+    return PgoFailure("profile validation", workspace);
+  }
+  std::cout << "Raw profiles:              " << raw_profiles.size() << '\n'
+            << "Total raw-profile bytes:   " << raw_bytes << '\n'
+            << "Total functions:           " << summary.total_functions << '\n'
+            << "Maximum function count:    " << summary.maximum_function_count << '\n'
+            << "Merged profile:            " << workspace.merged_profile << '\n';
+
+  const auto profile_hash = moderngekko::HashFileSha256(workspace.merged_profile);
+  if (!profile_hash)
+    return PgoFailure("profile validation", workspace);
+
+  std::cout << "\n[6/6] Building the PGO module\n";
+  BuildOptions use_options = options;
+  use_options.pgo.mode = moderngekko::pgo::PgoMode::Use;
+  // Absolute: this path is handed to a compiler that runs in the module build
+  // directory, not in the caller's working directory.
+  use_options.pgo.merged_profile = fs::absolute(workspace.merged_profile, ec);
+  if (ec)
+    use_options.pgo.merged_profile = workspace.merged_profile;
+  use_options.pgo.merged_profile_sha256 = *profile_hash;
+  use_options.pgo.reject_stale_profile = true;
+  use_options.pgo_facts.backend = options.backend;
+  use_options.pgo_facts.clang_version = clang_version;
+  use_options.pgo_facts.llvm_profdata_version = llvm_profdata_version;
+  use_options.pgo_facts.raw_profile_count = raw_profiles.size();
+  use_options.pgo_facts.total_functions = summary.total_functions;
+  use_options.pgo_facts.maximum_function_count = summary.maximum_function_count;
+  const auto module = Build(argv0, root, use_options);
+  if (!module)
+    return PgoFailure("PGO module build", workspace);
+
+  const auto module_hash = moderngekko::HashFileSha256(*module);
+  if (!module_hash)
+  {
+    std::cerr << "the PGO module is missing after a successful build: " << *module << '\n';
+    return PgoFailure("final module validation", workspace);
+  }
+
+  {
+    std::ofstream manifest(workspace.manifest);
+    manifest << "disc_id=" << game.disc_id << '\n'
+             << "dol_sha256=" << game.dol_sha256 << '\n'
+             << "module_path=" << moderngekko::pgo::PathText(*module) << '\n'
+             << "module_sha256=" << *module_hash << '\n'
+             << moderngekko::pgo::FormatPgoManifest(use_options.pgo, use_options.pgo_facts);
+  }
+
+  // Only now, with a published module and a written manifest, is it safe to
+  // drop the bulky intermediates. The merged profile and this manifest stay
+  // either way: they are what a later run, or a bug report, needs.
+  if (!pgo_options.keep_work)
+  {
+    fs::remove_all(workspace.raw, ec);
+    fs::remove_all(workspace.generate_modules, ec);
+  }
+
+  const fs::path active = options.output / game.disc_id / "active-module.txt";
+  std::cout << "\nPGO build complete\n"
+            << "Game:                  " << game.game_name << '\n'
+            << "Disc ID:               " << game.disc_id << '\n'
+            << "Backend:               " << options.backend << '\n'
+            << "Training run:          completed normally\n"
+            << "Raw profiles:          " << raw_profiles.size() << '\n'
+            << "Merged profile:        " << workspace.merged_profile << '\n'
+            << "Merged profile SHA256: " << *profile_hash << '\n'
+            << "Final module:          " << *module << '\n'
+            << "Final module SHA256:   " << *module_hash << '\n'
+            << "Active module updated: yes (" << active << ")\n"
+            << "PGO manifest:          " << workspace.manifest << '\n';
+  if (pgo_options.keep_work)
+    std::cout << "Work files kept:       " << workspace.root << '\n';
+  return 0;
+}
+
 void Usage()
 {
   std::cerr << "usage: moderngekko-port inspect <game-root>\n"
                "       moderngekko-port build <game-root> [--backend c|llvm] [--toolchain auto|clang|gcc|msvc] [--opt-level 0-3] [--output path]\n"
-               "       moderngekko-port run <game-root> [build options] [-- runner options]\n";
+               "       moderngekko-port run <game-root> [build options] [-- runner options]\n"
+               "       moderngekko-port pgo-run <game-root> [--backend c|llvm] [--toolchain auto|clang] [--opt-level 0-3]\n"
+               "               [--output path] [--profile-dir path] [--llvm-profdata path] [--keep-work]\n"
+               "               [-- runner options]\n";
 }
 }  // namespace
 
 int main(int argc, char** argv)
 {
-  if (argc < 3)
+  moderngekko::port::CommandLine parsed =
+      moderngekko::port::ParseCommandLine(argc, argv, DEFAULT_BACKEND);
+  if (parsed.usage)
   {
     Usage();
     return 2;
   }
-  const std::string command = argv[1];
-  const fs::path root = argv[2];
-  BuildOptions options;
-  bool runner_args = false;
-  for (int i = 3; i < argc; ++i)
+  if (!parsed)
   {
-    const std::string arg = argv[i];
-    if (runner_args)
-      options.runner_arguments.push_back(arg);
-    else if (arg == "--")
-      runner_args = true;
-    else if (arg == "--toolchain" && i + 1 < argc)
-      options.toolchain = argv[++i];
-    else if (arg == "--backend" && i + 1 < argc)
-      options.backend = argv[++i];
-    else if (arg == "--opt-level" && i + 1 < argc)
-      options.opt_level = argv[++i];
-    else if (arg == "--output" && i + 1 < argc)
-      options.output = argv[++i];
-    else if (command == "run")
-      options.runner_arguments.push_back(arg);
-    else
-    {
-      std::cerr << "unknown or incomplete option: " << arg << '\n';
-      return 2;
-    }
+    std::cerr << parsed.error << '\n';
+    return 2;
   }
+  const std::string& command = parsed.command;
+  const fs::path& root = parsed.root;
+  BuildOptions options = std::move(parsed.build);
   if (options.output.empty())
     options.output = DefaultOutput();
-  if (options.backend != "c" && options.backend != "llvm")
-  {
-    std::cerr << "unknown backend: " << options.backend << '\n';
-    return 2;
-  }
-  if (!options.opt_level.empty() &&
-      (options.opt_level.size() != 1 || options.opt_level[0] < '0' || options.opt_level[0] > '3'))
-  {
-    std::cerr << "opt level must be 0, 1, 2, or 3: " << options.opt_level << '\n';
-    return 2;
-  }
 #if !defined(MODERNGEKKO_DOLRECOMP_LLVM)
   if (options.backend == "llvm")
   {
@@ -675,11 +1130,8 @@ int main(int argc, char** argv)
 #endif
   if (command == "inspect")
     return Inspect(root, options.output);
-  if (command != "build" && command != "run")
-  {
-    Usage();
-    return 2;
-  }
+  if (command == "pgo-run")
+    return PgoRun(argv[0], root, options, parsed.pgo_run);
   const auto module = Build(argv[0], root, options);
   if (!module)
     return 1;

--- a/tools/moderngekko_port.cpp
+++ b/tools/moderngekko_port.cpp
@@ -93,6 +93,15 @@ std::string Text(const fs::path& value)
   return moderngekko::pgo::PathText(value);
 }
 
+std::string Trim(std::string value)
+{
+  while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
+    value.erase(value.begin());
+  while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
+    value.pop_back();
+  return value;
+}
+
 std::string FirstLine(std::string_view text)
 {
   const std::size_t end = text.find('\n');
@@ -110,8 +119,11 @@ std::string LineContaining(std::string_view text, std::string_view needle)
     const std::size_t end = text.find('\n', start);
     const std::string_view line =
         text.substr(start, end == std::string_view::npos ? std::string_view::npos : end - start);
+    // Trimmed: llvm-profdata indents its version banner under the "LLVM
+    // (http://llvm.org/):" heading, and that indentation would otherwise reach
+    // the manifest.
     if (line.find(needle) != std::string_view::npos)
-      return FirstLine(line);
+      return Trim(FirstLine(line));
     if (end == std::string_view::npos)
       break;
     start = end + 1;
@@ -206,15 +218,6 @@ std::uint64_t Fnv1a(std::string_view value)
   for (unsigned char c : value)
     hash = (hash ^ c) * 0x100000001b3ULL;
   return hash;
-}
-
-std::string Trim(std::string value)
-{
-  while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
-    value.erase(value.begin());
-  while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
-    value.pop_back();
-  return value;
 }
 
 std::uint32_t ReadBE32(const std::uint8_t* data)

--- a/tools/moderngekko_port.cpp
+++ b/tools/moderngekko_port.cpp
@@ -85,6 +85,14 @@ std::string Quote(const fs::path& value)
   return QuoteText(moderngekko::pgo::PathText(value));
 }
 
+// For printing. Streaming a path inserts quotes and doubles every backslash,
+// which is unreadable in a summary block a developer is meant to copy a path
+// out of.
+std::string Text(const fs::path& value)
+{
+  return moderngekko::pgo::PathText(value);
+}
+
 std::string FirstLine(std::string_view text)
 {
   const std::size_t end = text.find('\n');
@@ -387,7 +395,18 @@ bool PatchDol(const fs::path& input_path, const fs::path& output_path,
 std::string ReadCommand(const std::string& command)
 {
 #if defined(_WIN32)
-  FILE* pipe = _wpopen(Widen(command).c_str(), L"r");
+  // _wpopen runs the command through `cmd /c`, and cmd drops the quotes around
+  // a program path containing spaces as soon as a second quoted argument
+  // follows it:
+  //
+  //   "C:\Program Files\LLVM\bin\llvm-profdata.exe" show "C:\...\merged.profdata"
+  //   -> 'C:\Program' is not recognized as an internal or external command
+  //
+  // One quoted argument is fine, which is why probing `llvm-profdata --version`
+  // worked and reading the profile summary did not. Wrapping the whole command
+  // in one more pair makes cmd strip exactly that pair and pass the rest
+  // through untouched, which is the documented behaviour of `cmd /c "..."`.
+  FILE* pipe = _wpopen(Widen("\"" + command + "\"").c_str(), L"r");
 #else
   FILE* pipe = popen(command.c_str(), "r");
 #endif
@@ -405,7 +424,11 @@ std::string ReadCommand(const std::string& command)
   return output;
 }
 
-bool RunCommand(const std::string& command)
+// The exit status, or -1 if the command could not be launched at all. pgo-run
+// reports the training run's status rather than only that it was nonzero: a
+// game closed normally exits 0, and every other value is a different problem to
+// diagnose.
+int RunCommandStatus(const std::string& command)
 {
   std::cout << "+ " << command << '\n';
 #if defined(_WIN32)
@@ -419,17 +442,31 @@ bool RunCommand(const std::string& command)
                       &startup, &process))
   {
     std::cerr << "failed to launch command: Windows error " << GetLastError() << '\n';
-    return false;
+    return -1;
   }
   WaitForSingleObject(process.hProcess, INFINITE);
   DWORD exit_code = 1;
   const bool got_exit_code = GetExitCodeProcess(process.hProcess, &exit_code) != FALSE;
   CloseHandle(process.hThread);
   CloseHandle(process.hProcess);
-  return got_exit_code && exit_code == 0;
+  return got_exit_code ? static_cast<int>(exit_code) : -1;
 #else
-  return std::system(command.c_str()) == 0;
+  const int status = std::system(command.c_str());
+  if (status == -1)
+    return -1;
+#if defined(WIFEXITED)
+  if (WIFEXITED(status))
+    return WEXITSTATUS(status);
+  return -1;
+#else
+  return status;
 #endif
+#endif
+}
+
+bool RunCommand(const std::string& command)
+{
+  return RunCommandStatus(command) == 0;
 }
 
 fs::path SiblingExecutable(const char* argv0, std::string name)
@@ -828,7 +865,7 @@ int PgoFailure(std::string_view stage, const moderngekko::pgo::Workspace& worksp
   std::cerr << "\nPGO run failed during: " << stage << '\n'
             << "The previously active module is unchanged; no instrumented module was "
                "published.\n"
-            << "Work files kept for diagnosis: " << workspace.root << '\n';
+            << "Work files kept for diagnosis: " << Text(workspace.root) << '\n';
   return 1;
 }
 
@@ -907,7 +944,7 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
     std::cerr << "llvm-profdata is LLVM " << *profdata_major << " but clang is LLVM "
               << *clang_major << ".\n"
               << "  clang:         " << clang_version << '\n'
-              << "  llvm-profdata: " << llvm_profdata_version << " (" << llvm_profdata << ")\n"
+              << "  llvm-profdata: " << llvm_profdata_version << " (" << Text(llvm_profdata) << ")\n"
               << "The profile formats are not guaranteed compatible across major versions.\n"
                  "Pass --llvm-profdata with the matching binary.\n";
     return 1;
@@ -931,7 +968,7 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
         moderngekko::pgo::LongestModuleObjectPathLength(cache_root, game.disc_id);
     if (longest <= moderngekko::pgo::WINDOWS_PATH_LIMIT)
       continue;
-    std::cerr << "the module build under " << cache_root << " would need paths of up to "
+    std::cerr << "the module build under " << Text(cache_root) << " would need paths of up to "
               << longest << " characters, and Windows refuses to create a file past "
               << moderngekko::pgo::WINDOWS_PATH_LIMIT << ".\n"
               << "Pass a shorter " << label << " (for example " << label << " C:\\mg-pgo).\n";
@@ -948,14 +985,14 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
   fs::create_directories(workspace.raw, ec);
   if (ec)
   {
-    std::cerr << "could not prepare " << workspace.raw << ": " << ec.message() << '\n';
+    std::cerr << "could not prepare " << Text(workspace.raw) << ": " << ec.message() << '\n';
     return 1;
   }
   fs::create_directories(workspace.generate_modules, ec);
 
-  std::cout << "PGO workspace: " << workspace.root << "\n"
+  std::cout << "PGO workspace: " << Text(workspace.root) << "\n"
             << "clang:         " << clang_version << "\n"
-            << "llvm-profdata: " << llvm_profdata_version << " (" << llvm_profdata << ")\n";
+            << "llvm-profdata: " << llvm_profdata_version << " (" << Text(llvm_profdata) << ")\n";
 
   std::cout << "\n[1/6] Building the instrumented module\n";
   BuildOptions generate_options = options;
@@ -983,9 +1020,10 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
                       Quote(root) + " --module " + Quote(*instrumented);
     for (const std::string& arg : options.runner_arguments)
       run += " " + Quote(arg);
-    if (!RunCommand(run))
+    const int status = RunCommandStatus(run);
+    if (status != 0)
     {
-      std::cerr << "\nthe training run exited with a failure status.\n"
+      std::cerr << "\nthe training run exited with status " << status << ".\n"
                    "The profiling runtime flushes on a normal shutdown, so a crashed or "
                    "killed run has not written a usable profile.\n";
       return PgoFailure("training run", workspace);
@@ -1008,7 +1046,7 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
   }
   if (nonempty == 0)
   {
-    std::cerr << "no nonempty .profraw was written to " << workspace.raw << ".\n"
+    std::cerr << "no nonempty .profraw was written to " << Text(workspace.raw) << ".\n"
               << "The instrumented module did not flush a profile. Close the game through "
                  "its own quit path rather than killing it.\n";
     return PgoFailure("raw-profile discovery", workspace);
@@ -1025,7 +1063,7 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
   if (ec || merged_size == 0)
   {
     std::cerr << "llvm-profdata reported success but produced no usable "
-              << workspace.merged_profile << '\n';
+              << Text(workspace.merged_profile) << '\n';
     return PgoFailure("profile merge", workspace);
   }
 
@@ -1043,7 +1081,7 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
             << "Total raw-profile bytes:   " << raw_bytes << '\n'
             << "Total functions:           " << summary.total_functions << '\n'
             << "Maximum function count:    " << summary.maximum_function_count << '\n'
-            << "Merged profile:            " << workspace.merged_profile << '\n';
+            << "Merged profile:            " << Text(workspace.merged_profile) << '\n';
 
   const auto profile_hash = moderngekko::HashFileSha256(workspace.merged_profile);
   if (!profile_hash)
@@ -1072,7 +1110,7 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
   const auto module_hash = moderngekko::HashFileSha256(*module);
   if (!module_hash)
   {
-    std::cerr << "the PGO module is missing after a successful build: " << *module << '\n';
+    std::cerr << "the PGO module is missing after a successful build: " << Text(*module) << '\n';
     return PgoFailure("final module validation", workspace);
   }
 
@@ -1101,14 +1139,14 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
             << "Backend:               " << options.backend << '\n'
             << "Training run:          completed normally\n"
             << "Raw profiles:          " << raw_profiles.size() << '\n'
-            << "Merged profile:        " << workspace.merged_profile << '\n'
+            << "Merged profile:        " << Text(workspace.merged_profile) << '\n'
             << "Merged profile SHA256: " << *profile_hash << '\n'
-            << "Final module:          " << *module << '\n'
+            << "Final module:          " << Text(*module) << '\n'
             << "Final module SHA256:   " << *module_hash << '\n'
-            << "Active module updated: yes (" << active << ")\n"
-            << "PGO manifest:          " << workspace.manifest << '\n';
+            << "Active module updated: yes (" << Text(active) << ")\n"
+            << "PGO manifest:          " << Text(workspace.manifest) << '\n';
   if (pgo_options.keep_work)
-    std::cout << "Work files kept:       " << workspace.root << '\n';
+    std::cout << "Work files kept:       " << Text(workspace.root) << '\n';
   return 0;
 }
 

--- a/tools/moderngekko_port.cpp
+++ b/tools/moderngekko_port.cpp
@@ -918,6 +918,27 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
   const moderngekko::pgo::Workspace workspace =
       moderngekko::pgo::DeriveWorkspace(pgo_options.profile_dir, options.output, game.disc_id);
 
+#if defined(_WIN32)
+  // The generation build nests a second module cache under the workspace, which
+  // is enough to push an otherwise fine cache location past Windows' limit. The
+  // build that would fail takes twenty minutes to get there and then reports
+  // only "Unable to create file", so it is worth one second here instead.
+  for (const auto& [label, cache_root] :
+       {std::pair<std::string_view, const fs::path&>{"--profile-dir", workspace.generate_modules},
+        std::pair<std::string_view, const fs::path&>{"--output", options.output}})
+  {
+    const std::size_t longest =
+        moderngekko::pgo::LongestModuleObjectPathLength(cache_root, game.disc_id);
+    if (longest <= moderngekko::pgo::WINDOWS_PATH_LIMIT)
+      continue;
+    std::cerr << "the module build under " << cache_root << " would need paths of up to "
+              << longest << " characters, and Windows refuses to create a file past "
+              << moderngekko::pgo::WINDOWS_PATH_LIMIT << ".\n"
+              << "Pass a shorter " << label << " (for example " << label << " C:\\mg-pgo).\n";
+    return 1;
+  }
+#endif
+
   std::error_code ec;
   // A .profraw left by an earlier run describes an earlier module. Merged in,
   // it trains this one on code that may no longer exist, and the result still

--- a/tools/moderngekko_port.cpp
+++ b/tools/moderngekko_port.cpp
@@ -494,11 +494,11 @@ fs::path SiblingExecutable(const char* argv0, std::string name)
 // cache entries it already has.
 std::string DolRecompCodegenIdentity()
 {
-  constexpr std::array<const char*, 7> names = {
+  constexpr std::array<const char*, 8> names = {
       "DOLRECOMP_C_CHUNK_INSTRUCTIONS", "DOLRECOMP_LLVM_CHUNK_INSTRUCTIONS",
       "DOLRECOMP_LLVM_CPU",             "DOLRECOMP_LLVM_FEATURES",
       "DOLRECOMP_LLVM_TARGET",          "DOLRECOMP_DISPATCH_LOOKUP",
-      "DOLRECOMP_UNSAFE_DIRECT_CALLS"};
+      "DOLRECOMP_UNSAFE_DIRECT_CALLS", "DOLRECOMP_LLVM_WRITE_JOURNAL"};
   std::string identity;
   for (const char* name : names)
   {

--- a/tools/moderngekko_port.cpp
+++ b/tools/moderngekko_port.cpp
@@ -1108,7 +1108,34 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
   use_options.pgo_facts.maximum_function_count = summary.maximum_function_count;
   const auto module = Build(argv0, root, use_options);
   if (!module)
+  {
+    // By far the most common way this stage fails, and the error the
+    // recompiler prints -- "unsupported instrumentation profile format
+    // version", once per chunk worker -- says nothing about which of the three
+    // LLVMs involved disagreed.
+    //
+    // The profile is written by llvm-profdata and read back by the LLVM that
+    // DolRecomp is linked against, and those are separate installations. The
+    // check above compares clang against llvm-profdata, which catches the
+    // common case but cannot see DolRecomp's, because the recompiler does not
+    // report its own LLVM version. It also fails late: DolRecomp opens the
+    // profile eagerly (so a wrong path is caught) but only parses it inside
+    // PGOInstrumentationUse, after the emit has already started.
+    if (options.backend == "llvm")
+      std::cerr << "\nIf the recompiler reported \"unsupported instrumentation profile format "
+                   "version\",\nthe merged profile is newer than the LLVM DolRecomp is linked "
+                   "against.\n"
+                << "  llvm-profdata used here: " << llvm_profdata_version << '\n'
+                << "  clang used here:         " << clang_version << '\n'
+                << "The pinned recompiler builds against LLVM 19 or 20. Put that release's bin\n"
+                   "directory first on PATH so clang, its profiling runtime and llvm-profdata\n"
+                   "all match it, delete this workspace, and re-run. Overriding only\n"
+                   "--llvm-profdata is not enough: the module's C sources are compiled by\n"
+                   "whichever clang is on PATH, and that clang supplies the profiling runtime.\n"
+                << "Check what the recompiler links with: ldd "
+                << Text(SiblingExecutable(argv0, "dolrecomp")) << " | grep -i llvm\n";
     return PgoFailure("PGO module build", workspace);
+  }
 
   const auto module_hash = moderngekko::HashFileSha256(*module);
   if (!module_hash)

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -189,6 +189,8 @@ int RunMain(int argc, char **argv) {
       config.window_system = moderngekko::WindowSystem::X11;
     else if (arg == "--wayland")
       config.window_system = moderngekko::WindowSystem::Wayland;
+    else if (arg == "--mute")
+      config.audio.mute = true;
     else if (arg == "--automation-dir")
       config.automation.directory = value("--automation-dir");
     else if (arg == "--headless")

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -189,6 +189,8 @@ int RunMain(int argc, char **argv) {
       config.window_system = moderngekko::WindowSystem::X11;
     else if (arg == "--wayland")
       config.window_system = moderngekko::WindowSystem::Wayland;
+    else if (arg == "--automation-dir")
+      config.automation.directory = value("--automation-dir");
     else if (arg == "--headless")
       config.headless = true;
     else if (arg == "--allow-interpreter")

--- a/tools/pgo_support.cpp
+++ b/tools/pgo_support.cpp
@@ -1,0 +1,231 @@
+#include "pgo_support.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <sstream>
+#include <system_error>
+
+namespace moderngekko::pgo
+{
+namespace
+{
+#if defined(_WIN32)
+constexpr std::string_view LLVM_PROFDATA_NAME = "llvm-profdata.exe";
+#else
+constexpr std::string_view LLVM_PROFDATA_NAME = "llvm-profdata";
+#endif
+
+std::string Trim(std::string_view value)
+{
+  while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
+    value.remove_prefix(1);
+  while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
+    value.remove_suffix(1);
+  return std::string(value);
+}
+
+// `llvm-profdata show` prints "Total functions: 42". Nothing else on the line,
+// so the value is whatever follows the colon once the label matches exactly.
+bool ReadLabelledCount(std::string_view line, std::string_view label, std::uint64_t* value,
+                       bool* malformed)
+{
+  const std::string trimmed = Trim(line);
+  if (!trimmed.starts_with(label))
+    return false;
+  const std::string tail = Trim(std::string_view(trimmed).substr(label.size()));
+  if (tail.empty())
+  {
+    *malformed = true;
+    return true;
+  }
+  std::uint64_t parsed = 0;
+  const auto result = std::from_chars(tail.data(), tail.data() + tail.size(), parsed);
+  if (result.ec != std::errc{} || result.ptr != tail.data() + tail.size())
+  {
+    *malformed = true;
+    return true;
+  }
+  *value = parsed;
+  return true;
+}
+}  // namespace
+
+std::string_view PgoModeName(PgoMode mode)
+{
+  switch (mode)
+  {
+  case PgoMode::Generate:
+    return "generate";
+  case PgoMode::Use:
+    return "use";
+  case PgoMode::Off:
+    break;
+  }
+  return "off";
+}
+
+Workspace DeriveWorkspace(const fs::path& profile_dir, const fs::path& output,
+                          std::string_view disc_id)
+{
+  Workspace workspace;
+  workspace.root = profile_dir.empty() ? output / std::string(disc_id) / "pgo" : profile_dir;
+  workspace.raw = workspace.root / "raw";
+  workspace.generate_modules = workspace.root / "generate-modules";
+  workspace.merged_profile = workspace.root / "merged.profdata";
+  workspace.manifest = workspace.root / "pgo-manifest.txt";
+  return workspace;
+}
+
+std::string PathText(const fs::path& path)
+{
+  const std::u8string encoded = path.u8string();
+  return {encoded.begin(), encoded.end()};
+}
+
+std::string ClangPathText(const fs::path& path)
+{
+  const std::u8string encoded = path.generic_u8string();
+  return {encoded.begin(), encoded.end()};
+}
+
+ProfdataSummary ParseProfdataSummary(std::string_view text)
+{
+  ProfdataSummary summary;
+  bool saw_total = false;
+  bool saw_maximum = false;
+  bool malformed = false;
+
+  std::istringstream stream{std::string(text)};
+  std::string line;
+  while (std::getline(stream, line))
+  {
+    if (ReadLabelledCount(line, "Total functions:", &summary.total_functions, &malformed))
+      saw_total = true;
+    else if (ReadLabelledCount(line, "Maximum function count:", &summary.maximum_function_count,
+                               &malformed))
+      saw_maximum = true;
+  }
+
+  if (malformed)
+  {
+    summary.error = "llvm-profdata show produced a summary that could not be parsed";
+    return summary;
+  }
+  if (!saw_total || !saw_maximum)
+  {
+    summary.error = "llvm-profdata show reported no profile summary";
+    return summary;
+  }
+  if (summary.total_functions == 0)
+  {
+    summary.error = "the merged profile contains no function records";
+    return summary;
+  }
+  // A profile whose hottest function never executed is what an early flush
+  // looks like: the records exist because instrumentation created them, and
+  // every count is zero. Building against it produces an untrained module that
+  // reports as trained.
+  if (summary.maximum_function_count == 0)
+  {
+    summary.error = "the merged profile has a maximum function count of zero, so nothing "
+                    "was executed during training";
+    return summary;
+  }
+  return summary;
+}
+
+std::optional<int> ParseLlvmMajorVersion(std::string_view text)
+{
+  // "clang version 18.1.8", "Homebrew clang version 17.0.6", "LLVM (...)
+  // version 16.0.0". In every spelling the major number is the first digit run
+  // that follows the word "version".
+  constexpr std::string_view marker = "version";
+  std::size_t at = text.find(marker);
+  while (at != std::string_view::npos)
+  {
+    std::size_t cursor = at + marker.size();
+    while (cursor < text.size() && std::isspace(static_cast<unsigned char>(text[cursor])))
+      ++cursor;
+    const std::size_t start = cursor;
+    while (cursor < text.size() && std::isdigit(static_cast<unsigned char>(text[cursor])))
+      ++cursor;
+    if (cursor > start)
+    {
+      int value = 0;
+      const auto result = std::from_chars(text.data() + start, text.data() + cursor, value);
+      if (result.ec == std::errc{})
+        return value;
+    }
+    at = text.find(marker, at + marker.size());
+  }
+  return std::nullopt;
+}
+
+std::vector<fs::path> DiscoverRawProfiles(const fs::path& raw_directory)
+{
+  std::vector<fs::path> profiles;
+  std::error_code ec;
+  fs::recursive_directory_iterator it(raw_directory, fs::directory_options::skip_permission_denied,
+                                      ec);
+  if (ec)
+    return profiles;
+  for (const fs::directory_entry& entry : it)
+  {
+    if (entry.path().extension() != ".profraw")
+      continue;
+    std::error_code file_ec;
+    if (fs::is_regular_file(entry.path(), file_ec) && !file_ec)
+      profiles.push_back(entry.path());
+  }
+  std::sort(profiles.begin(), profiles.end());
+  return profiles;
+}
+
+std::vector<fs::path> LlvmProfdataCandidates(const LlvmProfdataSources& sources)
+{
+  std::vector<fs::path> candidates;
+  const auto add = [&candidates](const fs::path& candidate) {
+    if (candidate.empty())
+      return;
+    if (std::find(candidates.begin(), candidates.end(), candidate) == candidates.end())
+      candidates.push_back(candidate);
+  };
+
+  add(sources.explicit_path);
+  add(sources.environment_path);
+  if (sources.clang_path.has_parent_path())
+    add(sources.clang_path.parent_path() / LLVM_PROFDATA_NAME);
+  add(sources.print_prog_name);
+  add(sources.xcrun_path);
+  // Last: whatever PATH resolves the bare name to.
+  add(fs::path(std::string(LLVM_PROFDATA_NAME)));
+  return candidates;
+}
+
+std::string PgoCacheIdentity(const PgoBuildOptions& options)
+{
+  std::string identity = "pgo=" + std::string(PgoModeName(options.mode));
+  if (options.mode != PgoMode::Use)
+    return identity;
+  identity += "|pgo_profile_sha256=" + options.merged_profile_sha256;
+  identity += options.reject_stale_profile ? "|pgo_stale=error" : "|pgo_stale=warn";
+  return identity;
+}
+
+std::string FormatPgoManifest(const PgoBuildOptions& options, const ManifestFacts& facts)
+{
+  std::ostringstream out;
+  out << "pgo_mode=" << PgoModeName(options.mode) << '\n'
+      << "pgo_backend=" << facts.backend << '\n'
+      << "pgo_profile_sha256=" << options.merged_profile_sha256 << '\n'
+      << "pgo_profile_path=" << PathText(options.merged_profile) << '\n'
+      << "pgo_raw_profile_count=" << facts.raw_profile_count << '\n'
+      << "pgo_total_function_count=" << facts.total_functions << '\n'
+      << "pgo_max_function_count=" << facts.maximum_function_count << '\n'
+      << "pgo_stale_policy=" << (options.reject_stale_profile ? "error" : "warn") << '\n'
+      << "clang_version=" << facts.clang_version << '\n'
+      << "llvm_profdata_version=" << facts.llvm_profdata_version << '\n';
+  return out.str();
+}
+}  // namespace moderngekko::pgo

--- a/tools/pgo_support.cpp
+++ b/tools/pgo_support.cpp
@@ -71,10 +71,31 @@ Workspace DeriveWorkspace(const fs::path& profile_dir, const fs::path& output,
   Workspace workspace;
   workspace.root = profile_dir.empty() ? output / std::string(disc_id) / "pgo" : profile_dir;
   workspace.raw = workspace.root / "raw";
-  workspace.generate_modules = workspace.root / "generate-modules";
+  workspace.generate_modules = workspace.root / "gen";
   workspace.merged_profile = workspace.root / "merged.profdata";
   workspace.manifest = workspace.root / "pgo-manifest.txt";
   return workspace;
+}
+
+std::size_t LongestModuleObjectPathLength(const fs::path& cache_root, std::string_view disc_id)
+{
+  // Measured against a real build rather than guessed at: the cache key is a
+  // 64-character DOL digest, a dash and a 16-character identity hash; CMake
+  // interposes a 32-character directory hash; and the longest name emitted is a
+  // chunk of the form chunk_0012_text1_800316C0.c, which the response file adds
+  // ".obj.rsp" to.
+  constexpr std::size_t CACHE_KEY = 64 + 1 + 16;
+  constexpr std::size_t CMAKE_DIRECTORY_HASH = 32;
+  constexpr std::size_t LONGEST_OBJECT_NAME = std::string_view("chunk_0000_text1_80000000.c.obj.rsp").size();
+
+  std::size_t length = PathText(cache_root).size();
+  length += 1 + disc_id.size();                                 // /<disc>
+  length += 1 + CACHE_KEY;                                      // /<key>
+  length += std::string_view("/module-build/CMakeFiles/").size();
+  length += 1 + disc_id.size() + std::string_view("_recomp.dir").size();  // g<disc>_recomp.dir
+  length += 1 + CMAKE_DIRECTORY_HASH;
+  length += 1 + LONGEST_OBJECT_NAME;
+  return length;
 }
 
 std::string PathText(const fs::path& path)

--- a/tools/pgo_support.hpp
+++ b/tools/pgo_support.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+// The parts of `moderngekko-port pgo-run` that are worth testing on their own.
+//
+// The workflow itself -- build instrumented, play, merge, build again -- can
+// only be exercised with a game and a display. Everything it can get wrong
+// quietly cannot: a cache key that lets a plain module answer a PGO build, a
+// profile summary that is parsed as valid when it is empty, a raw-profile scan
+// that misses a file because the path has a space in it. Those live here, take
+// values rather than reading the filesystem or spawning processes where that is
+// possible, and are covered by tests that need neither a game nor Dolphin.
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace moderngekko::pgo
+{
+namespace fs = std::filesystem;
+
+enum class PgoMode
+{
+  Off,
+  Generate,
+  Use,
+};
+
+std::string_view PgoModeName(PgoMode mode);
+
+struct PgoBuildOptions
+{
+  PgoMode mode = PgoMode::Off;
+  fs::path merged_profile;
+  // The digest of merged_profile's *contents*. The path is deliberately not
+  // part of the build's identity: the same profile copied elsewhere is the same
+  // profile, and two different profiles written to the same scratch filename
+  // are not.
+  std::string merged_profile_sha256;
+  bool reject_stale_profile = true;
+};
+
+// Where a run keeps everything it produces. Separate directories rather than
+// one, because the instrumented module and the final module must never be able
+// to be confused for each other.
+struct Workspace
+{
+  fs::path root;
+  fs::path raw;               // <root>/raw          -- .profraw from the training run
+  fs::path generate_modules;  // <root>/generate-modules -- private module cache
+  fs::path merged_profile;    // <root>/merged.profdata
+  fs::path manifest;          // <root>/pgo-manifest.txt
+};
+
+// `profile_dir` empty derives a deterministic location under the module cache,
+// so a repeat run reuses the same workspace instead of scattering profiles.
+Workspace DeriveWorkspace(const fs::path& profile_dir, const fs::path& output,
+                          std::string_view disc_id);
+
+// UTF-8. std::filesystem::path::string() narrows through the active code page
+// on Windows, which mangles any path the user's code page cannot represent.
+std::string PathText(const fs::path& path);
+
+// Forward slashes on every platform. A Windows path reaches Clang inside
+// -fprofile-use=..., and reaches CMake inside a -D argument; backslashes are an
+// escape character to enough of that chain to be worth never emitting.
+std::string ClangPathText(const fs::path& path);
+
+struct ProfdataSummary
+{
+  std::uint64_t total_functions = 0;
+  std::uint64_t maximum_function_count = 0;
+  std::string error;
+
+  explicit operator bool() const { return error.empty(); }
+};
+
+// Parses `llvm-profdata show`. A profile that merged cleanly but holds nothing
+// -- the training process died before the runtime flushed, or never ran the
+// module at all -- is a successful command and a useless profile, so this is
+// what tells those apart. No minimum count is imposed beyond nonzero: a small
+// program with one hot function is a legitimate profile.
+ProfdataSummary ParseProfdataSummary(std::string_view text);
+
+// The leading integer of an LLVM version string, from either `clang --version`
+// or `llvm-profdata --version`. Used only to refuse a known mismatch; an
+// unparseable version yields nullopt and the check is skipped rather than
+// guessed at.
+std::optional<int> ParseLlvmMajorVersion(std::string_view text);
+
+// Every .profraw under `raw_directory`, recursively, sorted so a run is
+// reproducible. Anything that is not a regular .profraw file is ignored.
+std::vector<fs::path> DiscoverRawProfiles(const fs::path& raw_directory);
+
+// The candidates that could be llvm-profdata, in the order they should be
+// tried. Kept separate from actually probing them so the order is testable.
+struct LlvmProfdataSources
+{
+  fs::path explicit_path;     // --llvm-profdata
+  fs::path environment_path;  // $LLVM_PROFDATA
+  fs::path clang_path;        // the resolved clang, for its own directory
+  fs::path print_prog_name;   // clang --print-prog-name=llvm-profdata
+  fs::path xcrun_path;        // xcrun --find llvm-profdata
+};
+
+std::vector<fs::path> LlvmProfdataCandidates(const LlvmProfdataSources& sources);
+
+// The PGO contribution to the module cache key. Off is spelled out rather than
+// left empty: "no PGO" is a real answer that has to be distinguishable from
+// "instrumented", or a plain module satisfies a PGO build.
+std::string PgoCacheIdentity(const PgoBuildOptions& options);
+
+struct ManifestFacts
+{
+  std::string backend;
+  std::string clang_version;
+  std::string llvm_profdata_version;
+  std::size_t raw_profile_count = 0;
+  std::uint64_t total_functions = 0;
+  std::uint64_t maximum_function_count = 0;
+};
+
+// The `pgo_*` block appended to a module's manifest.txt, and written whole as
+// the workspace's pgo-manifest.txt. Enough to audit how a module was produced
+// without having the run's console output.
+std::string FormatPgoManifest(const PgoBuildOptions& options, const ManifestFacts& facts);
+}  // namespace moderngekko::pgo

--- a/tools/pgo_support.hpp
+++ b/tools/pgo_support.hpp
@@ -48,8 +48,11 @@ struct PgoBuildOptions
 struct Workspace
 {
   fs::path root;
-  fs::path raw;               // <root>/raw          -- .profraw from the training run
-  fs::path generate_modules;  // <root>/generate-modules -- private module cache
+  fs::path raw;               // <root>/raw   -- .profraw from the training run
+  // <root>/gen -- the instrumented module's own private cache root. Named that
+  // tersely on purpose: it prefixes a module build path that is already close
+  // to Windows' limit. See LongestModuleObjectPathLength.
+  fs::path generate_modules;
   fs::path merged_profile;    // <root>/merged.profdata
   fs::path manifest;          // <root>/pgo-manifest.txt
 };
@@ -58,6 +61,23 @@ struct Workspace
 // so a repeat run reuses the same workspace instead of scattering profiles.
 Workspace DeriveWorkspace(const fs::path& profile_dir, const fs::path& output,
                           std::string_view disc_id);
+
+// Windows refuses to create a file whose full path exceeds this, and ninja does
+// not use the \\?\ extended-length prefix, so the module build hits it as
+// "Unable to create file. No such file or directory" with nothing said about
+// paths.
+inline constexpr std::size_t WINDOWS_PATH_LIMIT = 260;
+
+// The longest path the module build will try to create under `cache_root`:
+//
+//   <cache_root>/<disc>/<64-hex dol>-<16-hex key>/module-build/CMakeFiles/
+//       g<disc>_recomp.dir/<32-hex>/<longest source name>.c.obj.rsp
+//
+// A plain build already sits close to the limit; pgo-run adds a workspace
+// directory in front of it, which is enough to push a normal cache location
+// over. Checking up front turns a twenty-minute build that dies with a
+// confusing ninja error into an immediate message naming --profile-dir.
+std::size_t LongestModuleObjectPathLength(const fs::path& cache_root, std::string_view disc_id);
 
 // UTF-8. std::filesystem::path::string() narrows through the active code page
 // on Windows, which mangles any path the user's code page cannot represent.

--- a/tools/port_command_line.hpp
+++ b/tools/port_command_line.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+// moderngekko-port's argument parsing, separated from the work it drives.
+//
+// It lived in main(), which meant the one part of the tool that every command
+// goes through was the one part no test could reach: `run` forwards unknown
+// arguments to the runner and `build` rejects them, `--` stops option parsing,
+// and pgo-run adds three options that must not leak into the others. Adding a
+// fourth command to that loop without a test is how `build --load-state` starts
+// silently succeeding.
+
+#include "pgo_support.hpp"
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace moderngekko::port
+{
+namespace fs = std::filesystem;
+
+struct BuildOptions
+{
+  std::string toolchain = "auto";
+  // Empty means "leave the module template's own default alone". Any other
+  // value is forwarded as RECOMPCORE_MODULE_OPT_LEVEL and folded into the
+  // cache key, so an -O3 module cannot collide with an -O2 one.
+  std::string opt_level;
+  std::string backend;
+  fs::path output;
+  std::vector<std::string> runner_arguments;
+  // PGO is a semantic build input, not an ambient flag the caller happens to
+  // have exported: it changes what is compiled, what is linked, what DolRecomp
+  // emits, and -- through PgoCacheIdentity -- which cache entry may answer.
+  pgo::PgoBuildOptions pgo;
+  // Only recorded, never part of the cache key. Kept beside the build so the
+  // publish step can write the provenance block without pgo-run reaching back
+  // into the artifact directory afterwards.
+  pgo::ManifestFacts pgo_facts;
+};
+
+// Everything pgo-run needs that a plain build does not.
+struct PgoRunOptions
+{
+  fs::path profile_dir;
+  fs::path llvm_profdata;
+  bool keep_work = false;
+};
+
+struct CommandLine
+{
+  std::string command;
+  fs::path root;
+  BuildOptions build;
+  PgoRunOptions pgo_run;
+  // Empty on success. `usage` distinguishes "you asked for something that does
+  // not exist" from "that option is wrong", because the first wants the usage
+  // text and the second wants to say what was wrong.
+  std::string error;
+  bool usage = false;
+
+  explicit operator bool() const { return error.empty() && !usage; }
+};
+
+inline bool IsKnownCommand(std::string_view command)
+{
+  return command == "inspect" || command == "build" || command == "run" || command == "pgo-run";
+}
+
+inline CommandLine ParseCommandLine(int argc, const char* const* argv,
+                                    std::string_view default_backend)
+{
+  CommandLine parsed;
+  parsed.build.backend = std::string(default_backend);
+  if (argc < 3)
+  {
+    parsed.usage = true;
+    return parsed;
+  }
+  parsed.command = argv[1];
+  parsed.root = fs::path(argv[2]);
+  if (!IsKnownCommand(parsed.command))
+  {
+    parsed.usage = true;
+    return parsed;
+  }
+
+  // `run` and `pgo-run` end in a runner invocation, so an argument this tool
+  // does not recognise is meant for the runner rather than a mistake. `build`
+  // and `inspect` have nowhere to forward one, so for them it is an error.
+  const bool forwards_runner_arguments =
+      parsed.command == "run" || parsed.command == "pgo-run";
+  const bool is_pgo_run = parsed.command == "pgo-run";
+  bool runner_arguments = false;
+  for (int i = 3; i < argc; ++i)
+  {
+    const std::string argument = argv[i];
+    if (runner_arguments)
+      parsed.build.runner_arguments.push_back(argument);
+    else if (argument == "--")
+      runner_arguments = true;
+    else if (argument == "--toolchain" && i + 1 < argc)
+      parsed.build.toolchain = argv[++i];
+    else if (argument == "--backend" && i + 1 < argc)
+      parsed.build.backend = argv[++i];
+    else if (argument == "--opt-level" && i + 1 < argc)
+      parsed.build.opt_level = argv[++i];
+    else if (argument == "--output" && i + 1 < argc)
+      parsed.build.output = fs::path(argv[++i]);
+    else if (argument == "--profile-dir" && i + 1 < argc && is_pgo_run)
+      parsed.pgo_run.profile_dir = fs::path(argv[++i]);
+    else if (argument == "--llvm-profdata" && i + 1 < argc && is_pgo_run)
+      parsed.pgo_run.llvm_profdata = fs::path(argv[++i]);
+    else if (argument == "--keep-work" && is_pgo_run)
+      parsed.pgo_run.keep_work = true;
+    else if (forwards_runner_arguments)
+      parsed.build.runner_arguments.push_back(argument);
+    else
+    {
+      parsed.error = "unknown or incomplete option: " + argument;
+      return parsed;
+    }
+  }
+
+  if (parsed.build.backend != "c" && parsed.build.backend != "llvm")
+  {
+    parsed.error = "unknown backend: " + parsed.build.backend;
+    return parsed;
+  }
+  if (!parsed.build.opt_level.empty() &&
+      (parsed.build.opt_level.size() != 1 || parsed.build.opt_level[0] < '0' ||
+       parsed.build.opt_level[0] > '3'))
+  {
+    parsed.error = "opt level must be 0, 1, 2, or 3: " + parsed.build.opt_level;
+    return parsed;
+  }
+  return parsed;
+}
+}  // namespace moderngekko::port


### PR DESCRIPTION
The module reuse identity hashes six `DOLRECOMP_*` environment knobs but not the write-journal flag, so toggling `DOLRECOMP_LLVM_WRITE_JOURNAL` silently reuses a module generated without journaling. Found while instrumenting Pokemon Colosseum (ExpansionPak/DolRecomp#20): a freshly generated "journaled" module produced zero journal calls because the port had quietly reused the previous build.