### PR TITLE
Forward --state-in-memory to dolrecomp

### DIFF
--- a/tools/moderngekko_port.cpp
+++ b/tools/moderngekko_port.cpp
@@ -675,6 +675,7 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
       std::to_string(MODERNGEKKO_MODULE_ABI_VERSION) + "|cpu-abi=" +
       std::to_string(MODERNGEKKO_CPU_ABI_VERSION) + "|" + compiler_identity + "|" +
       std::string(architecture) + "|" + flags + "|backend=" + options.backend +
+      (options.state_in_memory ? std::string("|state_in_memory=1") : std::string()) +
       "|patches=" + patches.fingerprint + "|dolrecomp_binary=" +
       *dolrecomp_hash + "|" + moderngekko::pgo::PgoCacheIdentity(options.pgo) +
       DolRecompCodegenIdentity();
@@ -710,6 +711,7 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
              << "architecture=" << architecture << '\n'
              << "flags=" << flags << '\n'
              << "backend=" << options.backend << '\n'
+             << "state_in_memory=" << (options.state_in_memory ? 1 : 0) << '\n'
              << "patches=" << patches.fingerprint << '\n';
     if (options.pgo.mode != moderngekko::pgo::PgoMode::Off)
       manifest << moderngekko::pgo::FormatPgoManifest(options.pgo, options.pgo_facts);
@@ -757,6 +759,8 @@ std::optional<fs::path> Build(const char* argv0, const fs::path& root,
   std::string generate = Quote(dolrecomp) + " -j" +
                          std::to_string(std::max(1u, std::thread::hardware_concurrency())) +
                          " --backend=" + options.backend + " ";
+  if (options.state_in_memory)
+    generate += "--state-in-memory ";
   if (game.platform == moderngekko::GamePlatform::GameCube)
     generate += "--cpu gekko --gamecube " + Quote(recomp_dol) + " " + Quote(generated_parent);
   else
@@ -1120,7 +1124,7 @@ int PgoRun(const char* argv0, const fs::path& root, BuildOptions options,
 void Usage()
 {
   std::cerr << "usage: moderngekko-port inspect <game-root>\n"
-               "       moderngekko-port build <game-root> [--backend c|llvm] [--toolchain auto|clang|gcc|msvc] [--opt-level 0-3] [--output path]\n"
+               "       moderngekko-port build <game-root> [--backend c|llvm] [--state-in-memory] [--toolchain auto|clang|gcc|msvc] [--opt-level 0-3] [--output path]\n"
                "       moderngekko-port run <game-root> [build options] [-- runner options]\n"
                "       moderngekko-port pgo-run <game-root> [--backend c|llvm] [--toolchain auto|clang] [--opt-level 0-3]\n"
                "               [--output path] [--profile-dir path] [--llvm-profdata path] [--keep-work]\n"

--- a/tools/port_command_line.hpp
+++ b/tools/port_command_line.hpp
@@ -16,6 +16,7 @@ struct BuildOptions
   std::string toolchain = "auto";
   std::string opt_level;
   std::string backend;
+  bool state_in_memory = false;
   fs::path output;
   std::vector<std::string> runner_arguments;
   pgo::PgoBuildOptions pgo;
@@ -80,6 +81,10 @@ inline CommandLine ParseCommandLine(int argc, const char* const* argv,
       parsed.build.toolchain = argv[++i];
     else if (argument == "--backend" && i + 1 < argc)
       parsed.build.backend = argv[++i];
+    else if (argument == "--state-in-memory")
+      parsed.build.state_in_memory = true;
+    else if (argument == "--no-state-in-memory")
+      parsed.build.state_in_memory = false;
     else if (argument == "--opt-level" && i + 1 < argc)
       parsed.build.opt_level = argv[++i];
     else if (argument == "--output" && i + 1 < argc)


### PR DESCRIPTION
DolRecomp replaced the `DOLRECOMP_STATE_MEMORY` environment variable with a `--state-in-memory` flag (folded into its own codegen hash in `src/app/pipeline.c`), but `moderngekko-port` was never taught to pass it. There is currently no way to build a state-in-memory module through the port tool — the environment variable no longer does anything, and the flag never reaches `dolrecomp`.

The flag also goes into the module cache identity and the manifest, for the same reason `backend` does: two builds differing only in it produce different code and must not share a cache entry, and anything comparing them needs the manifests to show which is which. Without that, the second build is silently served the first one's module.

`DolRecompCodegenIdentity()` is deliberately left alone — this is a command-line flag, not one of the environment variables that helper collects.

Found while A/B testing the C and LLVM backends on Pokemon Colosseum, where the two arms need to differ in exactly one thing and the manifests are what proves it.