### PR TITLE
Add --cache-affinity, and record what it is worth across four titles

### DIFF
--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -48,6 +49,7 @@ void Usage() {
                "       [--graphics <backend>] [--audio <backend>]\n"
                "       [--mods <directory>] [--no-mods]\n"
                "       [--wayland] [-X11] [--headless] [--allow-interpreter]\n"
+               "       [--cache-affinity | --no-cache-affinity]\n"
                "       [--netplay-host | --netplay-join <host>] "
                "[--netplay-port <port>]\n"
                "       [--nickname <name>] [--buffer <auto|1-20>] "
@@ -197,6 +199,11 @@ int RunMain(int argc, char **argv) {
       config.headless = true;
     else if (arg == "--allow-interpreter")
       config.allow_interpreter = true;
+    else if (arg == "--cache-affinity" || arg == "--no-cache-affinity")
+      // Already handled before the run started, in PinProcessToLargestCache().
+      // Accepted here so the parse does not reject it, and on every platform so
+      // a shared script can pass it without knowing the host.
+      ;
     else if (arg == "--netplay-host")
       netplay_role = moderngekko::frontend::NetplayRole::Host;
     else if (arg == "--netplay-join") {
@@ -425,11 +432,41 @@ int RunMain(int argc, char **argv) {
 // lose its working set. Measured on a 9950X3D: 55.41 -> 70.42 fps, +27%.
 //
 // This applies to every Dolphin thread, not only the emulated CPU thread, so it
-// is opt-in. Set MODERNGEKKO_CACHE_AFFINITY=1 to enable it after benchmarking
-// the target machine.
-void PinProcessToLargestCache() {
-  if (!moderngekko::frontend::AffinityEnabled(
-          std::getenv("MODERNGEKKO_CACHE_AFFINITY")))
+// stays opt-in: enable it with --cache-affinity, or MODERNGEKKO_CACHE_AFFINITY=1
+// for callers that cannot add an argument. --no-cache-affinity forces it off
+// even when the environment asks for it, which is what an A/B harness wants.
+//
+// Measured across four titles on a 9950X3D (96 MB L3 on one CCD), C backend,
+// three interleaved rounds per scene, same module and savestate throughout:
+//
+//   Pokemon Colosseum        +20.6%    Mario Kart: Double Dash!!   +32.9%
+//   Luigi's Mansion          +11.7%    Skyward Sword               +35.6%
+//
+// Twelve of twelve scenes improved, +5% to +43%, mean +25.2%. Pinning also cuts
+// run-to-run spread sharply -- one Colosseum scene went from +-0.297 to +-0.015
+// standard error over three samples -- so it makes benchmarking cheaper as well
+// as faster.
+//
+// What it is NOT is migration avoidance in general. Measured again on a 5900X --
+// two CCDs, 32 MB of L3 each, no asymmetry -- across four CPU-saturated scenes it
+// came out at -1.4%, with two scenes showing a small consistent loss. Pinning
+// there halves the cores the worker threads can use and buys nothing back,
+// because the die it avoids has exactly as much cache. The win depends on one
+// die having more, which is why the flag stays default-off.
+//
+// argv is scanned directly because pinning has to happen before the run starts,
+// which is well before the normal argument parse in RunMain().
+void PinProcessToLargestCache(int argc, char **argv) {
+  bool enabled = moderngekko::frontend::AffinityEnabled(
+      std::getenv("MODERNGEKKO_CACHE_AFFINITY"));
+  for (int i = 1; i < argc; i++) {
+    const std::string_view arg(argv[i]);
+    if (arg == "--cache-affinity")
+      enabled = true;
+    else if (arg == "--no-cache-affinity")
+      enabled = false;
+  }
+  if (!enabled)
     return;
 
   DWORD length = 0;
@@ -458,7 +495,7 @@ void PinProcessToLargestCache() {
 int main(int argc, char **argv) {
   try {
 #if defined(_WIN32)
-    PinProcessToLargestCache();
+    PinProcessToLargestCache(argc, argv);
 #endif
     return RunMain(argc, argv);
   } catch (const std::exception &error) {


### PR DESCRIPTION
## What

`PinProcessToLargestCache()` has been reachable only through an environment variable. Everything else the runner does is a command-line flag, so a harness that wants pinning has to reach outside the argument list to get it — and an A/B harness has no way to force it *off* for the control arm when the environment already asks for it.

```
--cache-affinity      enable pinning
--no-cache-affinity   disable it, overriding MODERNGEKKO_CACHE_AFFINITY
```

The flag wins over the environment in both directions. `argv` is scanned inside `PinProcessToLargestCache()` rather than in `RunMain()`, because pinning has to happen before the run starts. Both spellings are also accepted by the normal parser, on every platform, so a shared script can pass one without knowing the host.

## Why, with numbers

The existing comment cited a single measurement (55.41 → 70.42 fps). This replaces it with four titles on a 9950X3D (96 MB L3 on one CCD), C backend, three interleaved rounds per scene, same module and savestate throughout — only the environment differs between arms.

| title | gain | per-scene |
| --- | --- | --- |
| Pokémon Colosseum | **+20.6%** | +34%, +5%, +22% |
| Mario Kart: Double Dash!! | **+32.9%** | +39%, +38%, +22% |
| Luigi's Mansion | **+11.7%** | +10%, +9%, +16% |
| Skyward Sword | **+35.6%** | +43%, +28%, +36% |

Twelve of twelve scenes improved. Range +5% to +43%, mean **+25.2%**, median +25.0%.

It also cuts run-to-run spread sharply — pinned samples are far tighter:

| scene | off | on |
| --- | --- | --- |
| GC6E01 clean-field2 | 1.221 ±0.297 | 1.641 ±0.015 |
| GM4E01 course-baby-park | 2.147 ±0.126 | 2.974 ±0.031 |
| GLME01 bench | 0.978 ±0.006 | 1.077 ±0.022 |
| SOUE01 gameplay | 1.236 ±0.019 | 1.771 ±0.010 |

So it makes benchmarking cheaper as well as faster, which is a good reason for harnesses to want the explicit flag.

## What this does not claim — and a correction

The default stays **off**, and a second measurement has sharpened *why*.

I originally described this as avoiding thread migration between dies. That framing is wrong as a general claim. Running the same A/B on a **5900X** — two CCDs, 32 MB of L3 each, no asymmetry — over four CPU-saturated scenes gives **−1.4%**, with two scenes showing a small consistent loss (mean and median agreeing in sign):

| scene | off | on | |
| --- | --- | --- | --- |
| bench (4-player race) | 0.5025 | 0.5103 | +1.6% |
| play-GM4E01-019 | 0.6062 | 0.5884 | −2.9% |
| play-GM4E01-015 | 0.6127 | 0.6168 | +0.7% |
| play-GM4E01-003 | 0.5978 | 0.5683 | −4.9% |

Pinning on a symmetric part halves the cores available to the worker threads and buys nothing back, because the die it avoids has exactly as much cache. **The win depends on one die carrying more cache than the other** — the 9950X3D's 96 MB against 32 MB.

So this is a V-Cache-asymmetry optimisation, not a migration-avoidance one, and default-off is the right call for a stronger reason than "one machine, one topology". (Details and the Linux implementation are in the follow-up PR.)

## Verification

Built clean on Windows (MSVC). Both directions checked against the live process affinity mask:

- `--cache-affinity` with no environment variable → mask `0xFFFF` (pinned to one CCD, 16 of 32 logical processors)
- `--no-cache-affinity` with `MODERNGEKKO_CACHE_AFFINITY=1` set → mask `0xFFFFFFFF` (not pinned)

## Cross-platform

The pinning body is `#if defined(_WIN32)`, so off Windows there is nothing to measure — what matters is that the argument compiles and is *accepted* everywhere, since that is what lets a shared script pass it without knowing the host.

| toolchain | target | result |
| --- | --- | --- |
| MSVC 14.50 | x86-64 Windows | links; flag verified in both directions against the process mask |
| clang-cl 20.1.8 | x86-64 Windows | compiles, 0 errors (8 warnings, all pre-existing `getenv` deprecations) |
| Apple clang 17.0.0 | arm64 macOS 26.1 | links; flag accepted, correctly inert |
| GCC 13.3.0 | x86-64 Linux (Ubuntu 24.04) | links; flag accepted, correctly inert |
| aarch64 cross | arm64 Linux | links |

"Accepted" means `--cache-affinity` reaches the game-loading stage rather than being rejected as an unknown argument, and `--help` lists it.

