### PR TITLE
Implement cache pinning on Linux, and report that it measures flat there

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -858,8 +858,10 @@ if(BUILD_TESTING)
     add_test(NAME moderngekko.cpu_primitives
              COMMAND moderngekko_cpu_primitives_test)
 
-    if(WIN32)
-        # Header-only, and Windows-only like the rule it covers.
+    if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        # Header-only, and built wherever the rule it covers has an
+        # implementation. On other platforms the test is a no-op main, so there
+        # is nothing to run.
         add_executable(moderngekko_cache_affinity_test
             tests/cache_affinity_test.cpp)
         target_include_directories(moderngekko_cache_affinity_test PRIVATE

--- a/tests/cache_affinity_test.cpp
+++ b/tests/cache_affinity_test.cpp
@@ -4,6 +4,8 @@
 // hand and the selection rule is checked against it.
 #include "cache_affinity.hpp"
 
+#if defined(_WIN32)
+
 #include <cstring>
 #include <vector>
 
@@ -194,3 +196,114 @@ int main() {
 
   return 0;
 }
+
+#elif defined(__linux__)
+
+// The Linux rule reads sysfs, so the interesting topologies are supplied as a
+// fixture tree rather than by the machine running the test -- same reason the
+// Windows half is handed a synthetic buffer.
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace {
+namespace fs = std::filesystem;
+using moderngekko::frontend::CacheDomain;
+using moderngekko::frontend::LargestSharedCache;
+using moderngekko::frontend::ParseCacheSize;
+using moderngekko::frontend::ParseCpuList;
+
+void Write(const fs::path &path, const std::string &text) {
+  fs::create_directories(path.parent_path());
+  std::ofstream(path) << text << '\n';
+}
+
+// One cache record as the kernel lays it out: per-CPU directories, each listing
+// every cache that CPU can see.
+void AddCache(const fs::path &root, int cpu, int index, int level,
+              const std::string &size, const std::string &shared) {
+  const fs::path dir =
+      root / ("cpu" + std::to_string(cpu)) / "cache" / ("index" + std::to_string(index));
+  Write(dir / "level", std::to_string(level));
+  Write(dir / "size", size);
+  Write(dir / "shared_cpu_list", shared);
+}
+} // namespace
+
+int main() {
+  if (ParseCpuList("0-5,12-17") !=
+      std::vector<int>{0, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16, 17})
+    return 1;
+  if (ParseCpuList("3") != std::vector<int>{3})
+    return 2;
+  if (ParseCpuList("0-2,7") != std::vector<int>{0, 1, 2, 7})
+    return 3;
+  // Trailing newline is what actually comes back from sysfs.
+  if (ParseCpuList("0-1\n") != std::vector<int>{0, 1})
+    return 4;
+  // Malformed input yields nothing rather than a partial list: pinning to a
+  // wrong domain is worse than not pinning.
+  if (!ParseCpuList("").empty() || !ParseCpuList("2-1").empty() ||
+      !ParseCpuList("0,,3").empty() || !ParseCpuList("a-b").empty() ||
+      !ParseCpuList("0-").empty())
+    return 5;
+
+  if (ParseCacheSize("32768K") != 32768ull * 1024)
+    return 6;
+  if (ParseCacheSize("32M") != 32ull * 1024 * 1024)
+    return 7;
+  if (ParseCacheSize("512") != 512)
+    return 8;
+  if (ParseCacheSize("") != 0 || ParseCacheSize("K") != 0 || ParseCacheSize("12X") != 0)
+    return 9;
+
+  const fs::path root = fs::temp_directory_path() / "mg_cache_affinity_test";
+  std::error_code ec;
+  fs::remove_all(root, ec);
+
+  // A 5900X-shaped part: two equal CCDs, 32 MB each. Either is a valid answer;
+  // what matters is that one whole domain wins rather than a mix.
+  for (int cpu = 0; cpu < 4; cpu++) {
+    AddCache(root, cpu, 0, 1, "32K", std::to_string(cpu));
+    AddCache(root, cpu, 3, 3, "32768K", cpu < 2 ? "0-1" : "2-3");
+  }
+  {
+    const CacheDomain domain = LargestSharedCache(root);
+    if (!domain || domain.size != 32768ull * 1024)
+      return 10;
+    if (domain.cpus != std::vector<int>{0, 1} && domain.cpus != std::vector<int>{2, 3})
+      return 11;
+  }
+
+  // Now make one die's cache larger, as a V-Cache part does. The rule must pick
+  // that die specifically, not merely some die.
+  AddCache(root, 2, 3, 3, "98304K", "2-3");
+  AddCache(root, 3, 3, 3, "98304K", "2-3");
+  {
+    const CacheDomain domain = LargestSharedCache(root);
+    if (!domain || domain.cpus != std::vector<int>{2, 3})
+      return 12;
+    if (domain.size != 98304ull * 1024)
+      return 13;
+  }
+
+  // No level-3 entries at all: nothing to pin to, and that is not an error.
+  fs::remove_all(root, ec);
+  AddCache(root, 0, 0, 1, "32K", "0");
+  if (LargestSharedCache(root))
+    return 14;
+
+  // A missing tree behaves the same way rather than throwing.
+  fs::remove_all(root, ec);
+  if (LargestSharedCache(root / "absent"))
+    return 15;
+
+  fs::remove_all(root, ec);
+  return 0;
+}
+
+#else
+
+int main() { return 0; }
+
+#endif

--- a/tools/cache_affinity.hpp
+++ b/tools/cache_affinity.hpp
@@ -8,8 +8,26 @@
 // demand by the machine running the tests, and the rule is the part that decides
 // whether the pin helps or does nothing.
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace moderngekko::frontend
+{
+// Process-wide affinity can interfere with Dolphin's worker threads, so require
+// an exact, explicit opt-in instead of changing every launch by default.
+inline bool AffinityEnabled(const char* value)
+{
+  return value != nullptr && value[0] == '1' && value[1] == '\0';
+}
+
+struct PinResult
+{
+  bool affinity_set = false;
+};
+}  // namespace moderngekko::frontend
 
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
@@ -62,18 +80,6 @@ inline CacheDomain LargestSharedCache(const void* records, std::size_t bytes, BY
   return best;
 }
 
-// Process-wide affinity can interfere with Dolphin's worker threads, so require
-// an exact, explicit opt-in instead of changing every launch by default.
-inline bool AffinityEnabled(const char* value)
-{
-  return value != nullptr && value[0] == '1' && value[1] == '\0';
-}
-
-struct PinResult
-{
-  bool affinity_set = false;
-};
-
 // Applies a domain to a process. Separate from choosing one so a test can hand
 // it a real process handle and read the result back out of the OS.
 //
@@ -88,4 +94,197 @@ inline PinResult ApplyCacheDomain(HANDLE process, const CacheDomain& domain)
   return result;
 }
 }  // namespace moderngekko::frontend
-#endif  // _WIN32
+
+#elif defined(__linux__)
+
+#include <sched.h>
+#include <unistd.h>
+
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+#include <vector>
+
+// Linux exposes the same topology through sysfs. Each logical CPU has one
+// directory per cache it sees; a level-3 entry lists every CPU sharing that
+// cache in `shared_cpu_list`, so the distinct lists across all CPUs are the
+// domains, and `size` picks between them.
+//
+// The sysfs root is a parameter so a test can point it at a fixture tree. The
+// layouts that matter -- one die with a larger victim cache, one uniform cache
+// spanning every core -- are not reproducible on demand on the test machine,
+// which is the same reason the Windows rule takes a buffer rather than calling
+// the OS itself.
+namespace moderngekko::frontend
+{
+struct CacheDomain
+{
+  std::vector<int> cpus;
+  unsigned long long size = 0;
+
+  // No CPUs means nothing matched, so there is nothing to pin to.
+  explicit operator bool() const { return !cpus.empty(); }
+};
+
+// "0-5,12-17" -> 0 1 2 3 4 5 12 13 14 15 16 17
+//
+// Malformed input yields an empty list rather than a partial one: a domain that
+// is wrong is worse than a domain that is missing, because the caller pins to it.
+inline std::vector<int> ParseCpuList(std::string_view text)
+{
+  std::vector<int> cpus;
+  while (!text.empty() && (text.back() == '\n' || text.back() == ' '))
+    text.remove_suffix(1);
+  while (!text.empty())
+  {
+    const std::size_t comma = text.find(',');
+    std::string_view item = text.substr(0, comma);
+    text = comma == std::string_view::npos ? std::string_view() : text.substr(comma + 1);
+    if (item.empty())
+      return {};
+
+    const std::size_t dash = item.find('-');
+    const auto number = [](std::string_view s, int* out) {
+      if (s.empty())
+        return false;
+      int value = 0;
+      for (const char c : s)
+      {
+        if (c < '0' || c > '9')
+          return false;
+        // A CPU index this large is not a topology, it is a malformed file.
+        if (value > 100000)
+          return false;
+        value = value * 10 + (c - '0');
+      }
+      *out = value;
+      return true;
+    };
+
+    int first = 0;
+    int last = 0;
+    if (dash == std::string_view::npos)
+    {
+      if (!number(item, &first))
+        return {};
+      last = first;
+    }
+    else if (!number(item.substr(0, dash), &first) ||
+             !number(item.substr(dash + 1), &last) || last < first)
+    {
+      return {};
+    }
+    for (int cpu = first; cpu <= last; cpu++)
+      cpus.push_back(cpu);
+  }
+  return cpus;
+}
+
+// "32768K" / "32M" / "512" -> bytes. Returns 0 for anything unrecognised.
+inline unsigned long long ParseCacheSize(std::string_view text)
+{
+  unsigned long long value = 0;
+  std::size_t i = 0;
+  for (; i < text.size() && text[i] >= '0' && text[i] <= '9'; i++)
+    value = value * 10 + static_cast<unsigned>(text[i] - '0');
+  if (i == 0)
+    return 0;
+  if (i < text.size())
+  {
+    switch (text[i])
+    {
+    case 'K':
+    case 'k':
+      value *= 1024ull;
+      break;
+    case 'M':
+    case 'm':
+      value *= 1024ull * 1024ull;
+      break;
+    case 'G':
+    case 'g':
+      value *= 1024ull * 1024ull * 1024ull;
+      break;
+    case '\n':
+    case '\0':
+      break;
+    default:
+      return 0;
+    }
+  }
+  return value;
+}
+
+inline std::string ReadSysfsFile(const std::filesystem::path& path)
+{
+  std::ifstream input(path);
+  if (!input)
+    return {};
+  std::string text;
+  std::getline(input, text);
+  return text;
+}
+
+// Ties keep the first domain seen in CPU order, so the answer does not depend on
+// directory iteration order. On a part whose dies are identical that choice is
+// arbitrary and it does not matter which one wins -- what matters is that the
+// process stops migrating between them.
+inline CacheDomain LargestSharedCache(
+    const std::filesystem::path& sysfs_root = "/sys/devices/system/cpu", int level = 3)
+{
+  CacheDomain best;
+  std::error_code ec;
+  std::vector<std::vector<int>> seen;
+  for (int cpu = 0;; cpu++)
+  {
+    const std::filesystem::path cache_dir =
+        sysfs_root / ("cpu" + std::to_string(cpu)) / "cache";
+    if (!std::filesystem::exists(cache_dir, ec))
+      break;
+    for (int index = 0; index < 16; index++)
+    {
+      const std::filesystem::path entry = cache_dir / ("index" + std::to_string(index));
+      if (!std::filesystem::exists(entry, ec))
+        continue;
+      if (ReadSysfsFile(entry / "level") != std::to_string(level))
+        continue;
+      std::vector<int> cpus = ParseCpuList(ReadSysfsFile(entry / "shared_cpu_list"));
+      if (cpus.empty())
+        continue;
+      // The same domain is reported once per CPU in it; count it once.
+      if (std::find(seen.begin(), seen.end(), cpus) != seen.end())
+        continue;
+      seen.push_back(cpus);
+      const unsigned long long size = ParseCacheSize(ReadSysfsFile(entry / "size"));
+      if (size > best.size)
+        best = CacheDomain{std::move(cpus), size};
+    }
+  }
+  return best;
+}
+
+// An empty domain is not an error: there was nothing to pin to, and the
+// process's existing affinity is left alone.
+//
+// This pins the calling thread and every thread it later creates, which on Linux
+// means passing 0 rather than a pid: sched_setaffinity on the process id moves
+// only the main thread on some kernels, and Dolphin's workers are spawned after
+// this runs.
+inline PinResult ApplyCacheDomain(pid_t pid, const CacheDomain& domain)
+{
+  PinResult result;
+  if (!domain)
+    return result;
+  cpu_set_t set;
+  CPU_ZERO(&set);
+  for (const int cpu : domain.cpus)
+  {
+    if (cpu < 0 || cpu >= CPU_SETSIZE)
+      return result;
+    CPU_SET(cpu, &set);
+  }
+  result.affinity_set = sched_setaffinity(pid, sizeof(set), &set) == 0;
+  return result;
+}
+}  // namespace moderngekko::frontend
+#endif  // _WIN32 / __linux__

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -48,6 +49,7 @@ void Usage() {
                "       [--graphics <backend>] [--audio <backend>]\n"
                "       [--mods <directory>] [--no-mods]\n"
                "       [--wayland] [-X11] [--headless] [--allow-interpreter]\n"
+               "       [--cache-affinity | --no-cache-affinity]\n"
                "       [--netplay-host | --netplay-join <host>] "
                "[--netplay-port <port>]\n"
                "       [--nickname <name>] [--buffer <auto|1-20>] "
@@ -197,6 +199,11 @@ int RunMain(int argc, char **argv) {
       config.headless = true;
     else if (arg == "--allow-interpreter")
       config.allow_interpreter = true;
+    else if (arg == "--cache-affinity" || arg == "--no-cache-affinity")
+      // Already handled before the run started, in PinProcessToLargestCache().
+      // Accepted here so the parse does not reject it, and on every platform so
+      // a shared script can pass it without knowing the host.
+      ;
     else if (arg == "--netplay-host")
       netplay_role = moderngekko::frontend::NetplayRole::Host;
     else if (arg == "--netplay-join") {
@@ -425,11 +432,41 @@ int RunMain(int argc, char **argv) {
 // lose its working set. Measured on a 9950X3D: 55.41 -> 70.42 fps, +27%.
 //
 // This applies to every Dolphin thread, not only the emulated CPU thread, so it
-// is opt-in. Set MODERNGEKKO_CACHE_AFFINITY=1 to enable it after benchmarking
-// the target machine.
-void PinProcessToLargestCache() {
-  if (!moderngekko::frontend::AffinityEnabled(
-          std::getenv("MODERNGEKKO_CACHE_AFFINITY")))
+// stays opt-in: enable it with --cache-affinity, or MODERNGEKKO_CACHE_AFFINITY=1
+// for callers that cannot add an argument. --no-cache-affinity forces it off
+// even when the environment asks for it, which is what an A/B harness wants.
+//
+// Measured across four titles on a 9950X3D (96 MB L3 on one CCD), C backend,
+// three interleaved rounds per scene, same module and savestate throughout:
+//
+//   Pokemon Colosseum        +20.6%    Mario Kart: Double Dash!!   +32.9%
+//   Luigi's Mansion          +11.7%    Skyward Sword               +35.6%
+//
+// Twelve of twelve scenes improved, +5% to +43%, mean +25.2%. Pinning also cuts
+// run-to-run spread sharply -- one Colosseum scene went from +-0.297 to +-0.015
+// standard error over three samples -- so it makes benchmarking cheaper as well
+// as faster.
+//
+// What it is NOT is migration avoidance in general. Measured again on a 5900X --
+// two CCDs, 32 MB of L3 each, no asymmetry -- across four CPU-saturated scenes it
+// came out at -1.4%, with two scenes showing a small consistent loss. Pinning
+// there halves the cores the worker threads can use and buys nothing back,
+// because the die it avoids has exactly as much cache. The win depends on one
+// die having more, which is why the flag stays default-off.
+//
+// argv is scanned directly because pinning has to happen before the run starts,
+// which is well before the normal argument parse in RunMain().
+void PinProcessToLargestCache(int argc, char **argv) {
+  bool enabled = moderngekko::frontend::AffinityEnabled(
+      std::getenv("MODERNGEKKO_CACHE_AFFINITY"));
+  for (int i = 1; i < argc; i++) {
+    const std::string_view arg(argv[i]);
+    if (arg == "--cache-affinity")
+      enabled = true;
+    else if (arg == "--no-cache-affinity")
+      enabled = false;
+  }
+  if (!enabled)
     return;
 
   DWORD length = 0;
@@ -458,7 +495,7 @@ void PinProcessToLargestCache() {
 int main(int argc, char **argv) {
   try {
 #if defined(_WIN32)
-    PinProcessToLargestCache();
+    PinProcessToLargestCache(argc, argv);
 #endif
     return RunMain(argc, argv);
   } catch (const std::exception &error) {

--- a/tools/moderngekko_run.cpp
+++ b/tools/moderngekko_run.cpp
@@ -421,7 +421,6 @@ int RunMain(int argc, char **argv) {
   return 0;
 }
 
-#if defined(_WIN32)
 // Optionally confine the process to the cores that share the largest L3.
 //
 // The emulated CPU is a single serial instruction stream, so nothing here is
@@ -445,14 +444,9 @@ int RunMain(int argc, char **argv) {
 // Twelve of twelve scenes improved, +5% to +43%, mean +25.2%. Pinning also cuts
 // run-to-run spread sharply -- one Colosseum scene went from +-0.297 to +-0.015
 // standard error over three samples -- so it makes benchmarking cheaper as well
-// as faster.
-//
-// What it is NOT is migration avoidance in general. Measured again on a 5900X --
-// two CCDs, 32 MB of L3 each, no asymmetry -- across four CPU-saturated scenes it
-// came out at -1.4%, with two scenes showing a small consistent loss. Pinning
-// there halves the cores the worker threads can use and buys nothing back,
-// because the die it avoids has exactly as much cache. The win depends on one
-// die having more, which is why the flag stays default-off.
+// as faster. All of that is one machine and one topology, which is why the flag
+// stays default-off: a uniform-L3 part has nothing to gain, and a caller who
+// pins the wrong way can only lose.
 //
 // argv is scanned directly because pinning has to happen before the run starts,
 // which is well before the normal argument parse in RunMain().
@@ -468,6 +462,8 @@ void PinProcessToLargestCache(int argc, char **argv) {
   }
   if (!enabled)
     return;
+
+#if defined(_WIN32)
 
   DWORD length = 0;
   GetLogicalProcessorInformationEx(RelationCache, nullptr, &length);
@@ -489,14 +485,26 @@ void PinProcessToLargestCache(int argc, char **argv) {
               << " MB), mask 0x" << std::hex << static_cast<unsigned long long>(domain.mask)
               << std::dec << '\n';
   }
-}
+
+#elif defined(__linux__)
+  const moderngekko::frontend::CacheDomain domain =
+      moderngekko::frontend::LargestSharedCache();
+  if (!domain)
+    return;
+
+  // 0, not getpid(): this has to cover the threads Dolphin spawns after it, and
+  // a pid argument is documented to move the calling thread only.
+  if (moderngekko::frontend::ApplyCacheDomain(0, domain).affinity_set) {
+    std::cout << "[perf] pinned to the " << domain.cpus.size()
+              << " CPUs sharing the largest L3 (" << (domain.size >> 20) << " MB)"
+              << '\n';
+  }
 #endif
+}
 
 int main(int argc, char **argv) {
   try {
-#if defined(_WIN32)
     PinProcessToLargestCache(argc, argv);
-#endif
     return RunMain(argc, argv);
   } catch (const std::exception &error) {
     std::cerr << "fatal error: " << error.what() << '\n';


### PR DESCRIPTION
Stacked on #34. GitHub will not let me base a PR on a branch that lives only on my fork, so this opens against `master` and therefore **contains #34's commit as well**. Review #34 first; the second commit is what this PR is about. If #34 lands, this rebases to a single commit.

## What

The Windows path pins the process to the cores sharing the largest last-level cache. Linux exposes the same topology through sysfs, so the rule ports directly:

| | |
| --- | --- |
| `LargestSharedCache()` | reads `/sys/devices/system/cpu/cpu*/cache/index*`, de-duplicates the domain reported once per CPU in it, takes the largest by size, ties to the first in CPU order |
| `ParseCpuList()` | `"0-5,12-17"` → the CPUs in it |
| `ParseCacheSize()` | `"32768K"` → bytes |
| `ApplyCacheDomain()` | `sched_setaffinity(0, ...)` |

Two details worth calling out:

- **Malformed input yields an empty result, not a partial one.** Pinning to a wrong domain is worse than not pinning at all.
- **The affinity call takes `0`, not a pid.** A pid argument moves only the calling thread on some kernels, and Dolphin's workers are spawned after this runs.

`AffinityEnabled()` and `PinResult` move above the platform split so both paths share one opt-in rule. The sysfs root is a parameter so a test can point it at a fixture tree — the same reason the Windows rule takes a buffer rather than calling the OS itself.

## It measures flat, and that turns out to be the interesting part

**Choosing the workload mattered more than anything else here.** Screening 11 MKDD savestates showed most sit at exactly ~1.0x / 59.9 fps — they are keeping up with the guest, have headroom, and cannot show a cache effect at all. Only two were genuinely CPU-limited. Two earlier attempts at this measurement used scenes that were too light (one set ran at 3.09x realtime) and are not reported here.

Final run: idle 5900X — two CCDs, 32 MB L3 each — four CPU-saturated scenes (0.50x–0.61x), six interleaved rounds each, headless.

| scene | off | on | mean | median |
| --- | --- | --- | --- | --- |
| bench (4-player race) | 0.5025 ±0.0045 | 0.5103 ±0.0034 | +1.6% | +1.5% |
| play-GM4E01-019 | 0.6062 ±0.0157 | 0.5884 ±0.0147 | −2.9% | −3.3% |
| play-GM4E01-015 | 0.6127 ±0.0101 | 0.6168 ±0.0125 | +0.7% | +3.6% |
| play-GM4E01-003 | 0.5978 ±0.0153 | 0.5683 ±0.0059 | −4.9% | −2.8% |
| **overall** | | | **−1.4%** | |

Mean and median agree in sign on every scene, so this is not an underpowered null. Two scenes lose consistently, and plausibly: pinning to one CCD halves the cores available to Dolphin's worker threads, and on a part where the other die's cache is exactly as good, nothing is bought back.

**So the mechanism is cache asymmetry, not migration avoidance** — which corrects how I described it in #34, and is a better reason for the default to stay off. The +25.2% there came from a 9950X3D where one die carries 96 MB and the other 32 MB. No Linux host I have access to has that asymmetry, so the case this code exists for is implemented and tested but unmeasured.

Merge it for parity of mechanism, or hold it until someone can run it on a Linux V-Cache part — both are reasonable, and I would rather the choice be made with the null visible than buried.

Default stays off, as on Windows.

## Testing

`tests/cache_affinity_test.cpp` gains a Linux half: equal-CCD and larger-victim-cache fixture layouts, malformed cpu lists, no level-3 entries at all, and a missing tree. CMake builds it on Linux as well as Windows; elsewhere it is a no-op `main`.

- unit tests pass under **GCC 13.3** and **clang 18.1** with `-Wall -Wextra`
- the pin applies in a real run: `[perf] pinned to the 12 CPUs sharing the largest L3 (32 MB)`
- **MSVC** still builds and the Windows flag still behaves in both directions
