### PR TITLE
Repin RecompCore onto CPU ABI 4, and fail the build when the CPUState headers drift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,6 +788,25 @@ if(BUILD_TESTING)
     add_test(NAME moderngekko.module_abi
              COMMAND moderngekko_module_abi_test)
 
+    # Checks the vendored GXRuntime CPUState against the ABI version ModernGekko
+    # publishes. The two headers share the DOLRECOMP_CPU_H guard, so drift between
+    # them is invisible to every other target; this one compiles the GXRuntime
+    # header on its own so a mismatch fails the build instead of surfacing as a
+    # "CPU ABI mismatch" module rejection at run time.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vendor/dolphin/GXRuntime/include/core/cpu.h")
+        add_executable(moderngekko_cpu_abi_conformance_test
+            tests/cpu_abi_conformance_test.c
+        )
+        target_include_directories(moderngekko_cpu_abi_conformance_test PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/include"
+            "${CMAKE_CURRENT_SOURCE_DIR}/vendor/dolphin/GXRuntime/include")
+        add_test(NAME moderngekko.cpu_abi_conformance
+                 COMMAND moderngekko_cpu_abi_conformance_test)
+    else()
+        message(STATUS
+            "vendor/dolphin is not checked out; skipping the CPU ABI conformance test")
+    endif()
+
     add_library(moderngekko_test_module SHARED
         tests/fixtures/test_module.c
     )

--- a/include/moderngekko/cpu_abi_version.h
+++ b/include/moderngekko/cpu_abi_version.h
@@ -1,0 +1,23 @@
+#ifndef MODERNGEKKO_CPU_ABI_VERSION_H
+#define MODERNGEKKO_CPU_ABI_VERSION_H
+
+/* The CPU ABI version, kept in a header of its own.
+ *
+ * moderngekko/cpu_state.h and vendor/dolphin/GXRuntime/include/core/cpu.h both
+ * define `struct CPUState`, and both share the include guard DOLRECOMP_CPU_H so
+ * that a translation unit reaching for either one gets exactly one definition.
+ * That makes the two interchangeable, but it also means the second header to be
+ * included contributes nothing at all -- including its version macro.
+ *
+ * Keeping the version here, behind its own guard, means MODERNGEKKO_CPU_ABI_VERSION
+ * is defined regardless of which CPUState header won, and gives the conformance
+ * test something to compare GXRUNTIME_CPU_ABI_VERSION against without having to
+ * include two mutually exclusive headers in one translation unit.
+ *
+ * Version history:
+ *   3 - external_pointer and downcount tail extensions.
+ *   4 - cycle_budget, mirroring DolRecomp f0a86be, directly after downcount.
+ */
+#define MODERNGEKKO_CPU_ABI_VERSION 4u
+
+#endif

--- a/include/moderngekko/cpu_state.h
+++ b/include/moderngekko/cpu_state.h
@@ -1,3 +1,11 @@
+/* NOTE: DOLRECOMP_CPU_H is shared with GXRuntime's core/cpu.h by design --
+ * the two headers define the same struct, and the guard keeps a translation
+ * unit that reaches for both from seeing two definitions. They must therefore
+ * stay byte-compatible; tests/cpu_abi_conformance_test.c enforces that.
+ * The version macro lives outside the guard so it survives either ordering.
+ */
+#include "cpu_abi_version.h"
+
 #ifndef DOLRECOMP_CPU_H
 #define DOLRECOMP_CPU_H
 
@@ -8,8 +16,9 @@
 extern "C" {
 #endif
 
-#define MODERNGEKKO_CPU_ABI_VERSION 4u
+#ifndef GXRUNTIME_CPU_ABI_VERSION
 #define GXRUNTIME_CPU_ABI_VERSION MODERNGEKKO_CPU_ABI_VERSION
+#endif
 
 typedef struct CPUState CPUState;
 

--- a/tests/cpu_abi_conformance_test.c
+++ b/tests/cpu_abi_conformance_test.c
@@ -1,0 +1,52 @@
+/* Guards the seam between moderngekko/cpu_state.h and GXRuntime's core/cpu.h.
+ *
+ * Both headers define `struct CPUState` behind the shared guard DOLRECOMP_CPU_H,
+ * so a translation unit sees whichever one it included first and the other is
+ * silently skipped. That makes drift between them invisible at build time: it
+ * surfaces only when a recompiled module is rejected at load, or -- worse, if the
+ * ABI version happens to agree -- as fields read at the wrong offsets.
+ *
+ * This translation unit deliberately includes ONLY the GXRuntime header, then
+ * checks it against the version macro that moderngekko/cpu_state.h publishes
+ * separately. The two cannot both be included here; that is the point.
+ */
+#include "moderngekko/cpu_abi_version.h"
+
+#include <core/cpu.h>
+
+#include <stddef.h>
+
+_Static_assert(GXRUNTIME_CPU_ABI_VERSION == MODERNGEKKO_CPU_ABI_VERSION,
+               "GXRuntime and ModernGekko disagree on the CPU ABI version; the "
+               "vendor/dolphin pin and include/moderngekko/cpu_state.h must move "
+               "together");
+
+/* The tail layout that ABI 4 fixed. `cycle_budget` mirrors the field DolRecomp
+ * added to its generated-code CPUState in f0a86be; if it is missing or moves,
+ * every field after it shifts and generated code writes to the wrong offsets. */
+_Static_assert(offsetof(CPUState, cycle_budget) > offsetof(CPUState, downcount),
+               "cycle_budget must follow downcount");
+_Static_assert(offsetof(CPUState, exram) > offsetof(CPUState, cycle_budget),
+               "cycle_budget must sit between downcount and exram");
+_Static_assert(sizeof(((CPUState*)0)->cycle_budget) == 8u,
+               "cycle_budget is s64 in DolRecomp's generated-code prefix");
+_Static_assert(sizeof(((CPUState*)0)->downcount) == 8u,
+               "downcount is s64 in DolRecomp's generated-code prefix");
+
+/* The prefix generated code indexes directly. */
+_Static_assert(offsetof(CPUState, gpr) == 0,
+               "generated code expects CPUState.gpr at offset 0");
+_Static_assert(offsetof(CPUState, fpr) > offsetof(CPUState, gpr),
+               "CPUState register prefix order changed");
+_Static_assert(offsetof(CPUState, external_pointer) > offsetof(CPUState, ram_size),
+               "external_pointer must remain a tail extension");
+_Static_assert(offsetof(CPUState, spr_read) > offsetof(CPUState, exram_size),
+               "SPR callbacks must follow the exram pair");
+_Static_assert(offsetof(CPUState, cache_control) > offsetof(CPUState, spr_write),
+               "cache_control must remain the final field");
+
+int main(void)
+{
+    /* Everything here is checked at compile time. */
+    return 0;
+}


### PR DESCRIPTION
Stacked on ExpansionPak/RecompCore#21 — **do not merge before that one.**

## Problem

`master` has required CPU ABI 4 since `0fbc214` ("update recomp runtime"), which added `cycle_budget` to `cpu_state.h` and set `MODERNGEKKO_CPU_ABI_VERSION 4u`, tracking DolRecomp's `f0a86be`.

But `vendor/dolphin` still points at `55c7b023`, whose `GXRuntime/include/core/cpu.h` is at ABI 3 with no `cycle_budget`. The runtime requires 4; the header modules compile against says 3. Result, on a clean build of any title:

```
initialization failed: native module was rejected: CPU ABI mismatch
```

This is current upstream, reproducible from scratch. Trees cut before `f0a86be` are unaffected, which is why it went unnoticed.

## Why it was invisible

`include/moderngekko/cpu_state.h` and GXRuntime's `core/cpu.h` both define `struct CPUState` behind the same include guard, `DOLRECOMP_CPU_H`. That is deliberate — it keeps a translation unit reaching for either from seeing two definitions — but it means the second header contributes *nothing*, so no target in the tree ever compares them. An eight-byte layout split between generated code and the chassis produced no diagnostic at all until load time.

It has a sharper edge too: `MODERNGEKKO_CPU_ABI_VERSION` was defined inside that guard, so it silently disappears in any translation unit that reaches GXRuntime's header first.

## Changes

1. **Submodule pin** `55c7b023` → `52c6b46a`. No change to `cpu_state.h`; it is already correct and matches DolRecomp `main` field for field.
2. **`tests/cpu_abi_conformance_test.c`** — includes *only* the GXRuntime header, then asserts it against the version ModernGekko publishes, plus the tail layout ABI 4 fixed (`cycle_budget` between `downcount` and `exram`, both 8 bytes, `gpr` at offset 0, `cache_control` last). Skipped via `if(EXISTS ...)` when `vendor/dolphin` is not checked out.
3. **`include/moderngekko/cpu_abi_version.h`** — the version macro moves to its own header, included from outside the shared guard. The conformance test needs a value to compare against without including two mutually exclusive headers, and this also stops `MODERNGEKKO_CPU_ABI_VERSION` from vanishing on the unlucky include order.

The shared guard itself is left alone: renaming it would turn the current silent-skip into a hard redefinition error in any translation unit that includes both. Documented in place instead.

## Note on the cache

Once the vendored header reaches ABI 4, `moderngekko-port` re-keys automatically, since `MODERNGEKKO_CPU_ABI_VERSION` is folded into the cache identity. Existing ABI-3 modules under `build/modules/<ID>/` are simply no longer selected — no manual `rm -rf` needed.

## Verification

Built and tested on a Raspberry Pi 4 (aarch64, gcc, Linux 6.18):

- The conformance test compiles clean with `-Wall -Wextra` against the ABI 4 header this PR pins, and runs.
- Against the pre-fix header at `55c7b023` — that is, `master` as it stands today — it **fails to compile**, leading with:
  ```
  error: static assertion failed: "GXRuntime and ModernGekko disagree on the CPU ABI
  version; the vendor/dolphin pin and include/moderngekko/cpu_state.h must move together"
  ```
  followed by four `'CPUState' has no member named 'cycle_budget'` errors. That is the regression guard doing its job: this class of drift becomes a build failure instead of a runtime module rejection.
- The new CMake block was exercised end to end — `cmake` → `ninja` → `ctest` — giving `1/1 Passed`, and the `EXISTS` guard correctly emits its skip message when `vendor/dolphin` is absent.

Caveat on coverage: a full project configure was not possible on that machine (RecompCore's nested submodules unpopulated, no SDL3), so configure halts at `CMakeLists.txt:414` well before the new block at ~790. The block was therefore validated in isolation — same source file, same include directories, real `cmake`/`ctest` — but not in its position in the file. Worth a look at that CI job.